### PR TITLE
Add OpenAgent reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ npm uninstall -g @th0rgal/ralph-wiggum
 - [Original technique by Geoffrey Huntley](https://ghuntley.com/ralph/)
 - [Ralph Orchestrator](https://github.com/mikeyobrien/ralph-orchestrator)
 
+## See Also
+
+Check out [OpenAgent](https://github.com/Th0rgal/openagent) - a dashboard for orchestrating AI agents with workspace management, real-time monitoring, and multi-agent workflows.
+
 ## License
 
 MIT


### PR DESCRIPTION
Added a 'See Also' section to the README that references OpenAgent, a dashboard for orchestrating AI agents with workspace management and real-time monitoring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs update**
> 
> - Adds `See Also` section to `README.md` referencing `OpenAgent` with a brief description
> - Documentation-only change; no code modifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f747b75a807d79acab28e232df62d81189d51e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->