### PR TITLE
Add --allow-all flag for non-interactive permission auto-approval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0rgal/ralph-wiggum",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Ralph Wiggum technique for OpenCode - iterative AI development loops with self-correcting agents",
   "main": "bin/ralph.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Added `--allow-all` flag that auto-approves all tool permissions
- Enables fully autonomous operation in non-interactive environments
- Fixes issue where opencode prompts for permissions but user can't type to approve

## Test plan
- [x] Verified `--help` shows the new flag
- [x] Verified config generation with permissions set to "allow"
- [x] Tested end-to-end with a simple task

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds non-interactive permission auto-approval and refactors config handling**
> 
> - Introduces `--allow-all` flag (documented in `--help`) to auto-approve all OpenCode tool permissions for autonomous runs
> - Replaces `ensureFilteredPluginsConfig` with `ensureRalphConfig`, generating `.opencode/ralph-opencode.config.json` that supports both plugin filtering (auth-only when `--no-plugins`) and permission auto-approval
> - Sets `OPENCODE_CONFIG` when `--no-plugins` or `--allow-all` are used; logs "Permissions: auto-approve all tools" when applicable
> - Bumps version to `1.0.8`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65e3ad189f24c702f79ab906d72b5d9e11bd64e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->