### PR TITLE
Allow interactive permission approval via stdin passthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0rgal/ralph-wiggum",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Ralph Wiggum technique for OpenCode - iterative AI development loops with self-correcting agents",
   "main": "bin/ralph.js",
   "bin": {

--- a/ralph.ts
+++ b/ralph.ts
@@ -10,7 +10,7 @@ import { $ } from "bun";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "fs";
 import { join } from "path";
 
-const VERSION = "1.0.8";
+const VERSION = "1.0.9";
 
 // Context file path for mid-loop injection
 const stateDir = join(process.cwd(), ".opencode");
@@ -964,8 +964,10 @@ async function runRalphLoop(): Promise<void> {
       }
 
       // Run opencode using spawn for better argument handling
+      // stdin is inherited so users can respond to permission prompts if needed
       currentProc = Bun.spawn(["opencode", ...cmdArgs], {
         env,
+        stdin: "inherit",
         stdout: "pipe",
         stderr: "pipe",
       });


### PR DESCRIPTION
## Summary
- When opencode prompts for permissions, users can now type to approve directly
- Provides a middle ground between `--allow-all` (fully autonomous) and hanging
- Version bumped to 1.0.9

## Test plan
- [x] Verified ralph still works with stdin inherited
- [x] Version updated correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows users to interact with `opencode` permission prompts during runs.
> 
> - Passes `stdin: "inherit"` to `Bun.spawn` when invoking `opencode`
> - Bumps version to `1.0.9` in `package.json` and updates `VERSION` in `ralph.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d758a15020b8dbd3aad3a67097bfaf4e947069eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->