### PR TITLE
Add OpenAgent callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
   <a href="#commands">Commands</a>
 </p>
 
+<p align="center">
+  <strong>Tired of agents breaking your local environment?</strong><br>
+  <a href="https://github.com/Th0rgal/openagent">OpenAgent</a> gives each task an isolated Linux workspace. Self-hosted. Git-backed.
+</p>
+
 ---
 
 ## What is Ralph?


### PR DESCRIPTION
Adds a prominent callout promoting OpenAgent immediately after the navigation links. The new section leads with a pain-point (agents breaking local environments) and highlights the key benefits: isolated Linux workspaces, self-hosted, and git-backed.

This improves visibility of OpenAgent as a complementary solution for orchestrating AI agents safely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a prominent promotional callout in the README to surface OpenAgent as a complementary tool.
> 
> - Inserts a centered section after the navigation links emphasizing OpenAgent’s isolated Linux workspaces, self-hosted deployment, and git-backed workflow
> - No code changes; documentation-only update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd3d4de7ab14cc63e0f6388b9336d05e15664005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->