### PR TITLE
feat: Add GitHub Copilot CLI as fourth supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">Open Ralph Wiggum</h1>
-  <h3 align="center">Autonomous Agentic Loop for Claude Code, Codex & OpenCode</h3>
+  <h3 align="center">Autonomous Agentic Loop for Claude Code, Codex, Copilot CLI & OpenCode</h3>
 </p>
 
 <p align="center">
@@ -9,7 +9,7 @@
 
 <p align="center">
   <strong>Run any AI coding agent in a self-correcting loop until your task is done.</strong><br>
-  <em>Works with <b>Claude Code</b>, <b>OpenAI Codex</b>, and <b>OpenCode</b> — switch agents with <code>--agent</code>.</em><br>
+  <em>Works with <b>Claude Code</b>, <b>OpenAI Codex</b>, <b>Copilot CLI</b>, and <b>OpenCode</b> — switch agents with <code>--agent</code>.</em><br>
   <em>Based on the <a href="https://ghuntley.com/ralph/">Ralph Wiggum technique</a> by Geoffrey Huntley</em>
 </p>
 
@@ -42,6 +42,7 @@ Open Ralph Wiggum works with multiple AI coding agents. Switch between them usin
 |-------|------|-------------|
 | **Claude Code** | `--agent claude-code` | Anthropic's Claude Code CLI for autonomous coding |
 | **Codex** | `--agent codex` | OpenAI's Codex CLI for AI-powered development |
+| **Copilot CLI** | `--agent copilot` | GitHub Copilot CLI for agentic coding |
 | **OpenCode** | `--agent opencode` | Default agent, open-source AI coding assistant |
 
 ```bash
@@ -50,6 +51,9 @@ ralph "Build a REST API" --agent claude-code --max-iterations 10
 
 # Use OpenAI Codex
 ralph "Create a CLI tool" --agent codex --max-iterations 10
+
+# Use Copilot CLI
+ralph "Refactor the auth module" --agent copilot --max-iterations 10
 
 # Use OpenCode (default)
 ralph "Fix the failing tests" --max-iterations 10
@@ -78,6 +82,7 @@ Switch between AI coding agents without changing your workflow:
 
 - **Claude Code** (`--agent claude-code`) — Anthropic's powerful coding agent
 - **Codex** (`--agent codex`) — OpenAI's code-specialized model
+- **Copilot CLI** (`--agent copilot`) — GitHub's agentic coding tool
 - **OpenCode** (`--agent opencode`) — Open-source default option
 
 ## Key Features
@@ -107,6 +112,7 @@ Switch between AI coding agents without changing your workflow:
 - At least one AI coding agent CLI:
   - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — Anthropic's Claude Code CLI
   - [Codex](https://github.com/openai/codex) — OpenAI's Codex CLI
+  - [Copilot CLI](https://github.com/github/copilot-cli) — GitHub's Copilot CLI
   - [OpenCode](https://opencode.ai) — Open-source AI coding assistant
 
 ### npm (recommended)
@@ -157,6 +163,10 @@ ralph "Create a small CLI and document usage. Output <promise>COMPLETE</promise>
 ralph "Create a small CLI and document usage. Output <promise>COMPLETE</promise> when done." \
   --agent codex --model gpt-5-codex --max-iterations 5
 
+# Use Copilot CLI
+ralph "Create a small CLI and document usage. Output <promise>COMPLETE</promise> when done." \
+  --agent copilot --max-iterations 5
+
 # Complex project with Tasks Mode
 ralph "Build a full-stack web application with user auth and database" \
   --tasks --max-iterations 50
@@ -170,7 +180,7 @@ ralph "Build a full-stack web application with user auth and database" \
 ralph "<prompt>" [options]
 
 Options:
-  --agent AGENT            AI agent to use: opencode (default), claude-code, codex
+  --agent AGENT            AI agent to use: opencode (default), claude-code, codex, copilot
   --min-iterations N       Minimum iterations before completion allowed (default: 1)
   --max-iterations N       Stop after N iterations (default: unlimited)
   --completion-promise T   Text that signals completion (default: COMPLETE)
@@ -559,6 +569,36 @@ ralph "Generate unit tests for all utility functions" \
 ```bash
 ralph "Fix all TypeScript errors" --max-iterations 10
 ```
+
+### Copilot CLI
+
+[Copilot CLI](https://github.com/github/copilot-cli) is GitHub's agentic coding tool (public preview). It requires a GitHub Copilot subscription and authentication via `GH_TOKEN`, `GITHUB_TOKEN`, or prior `copilot /login`.
+
+**Install:**
+```bash
+npm install -g @github/copilot
+# or
+brew install copilot-cli
+```
+
+**Usage:**
+```bash
+ralph "Refactor the auth module and add tests" \
+  --agent copilot \
+  --max-iterations 15
+
+# With a specific model
+ralph "Build a REST API" \
+  --agent copilot \
+  --model claude-opus-4.6 \
+  --max-iterations 10
+```
+
+**Notes:**
+- Default model is Claude Sonnet 4.5; override with `--model`
+- `--allow-all` (default) maps to `--allow-all` + `--no-ask-user` in Copilot CLI
+- `--no-plugins` has no effect with Copilot CLI
+- Authentication: set `GH_TOKEN` / `GITHUB_TOKEN` env var, or run `copilot /login` first
 
 ## Learn More
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,12 +10,13 @@ if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
   exit 1
 }
 
-# Check for agent CLI (OpenCode, Claude Code, or Codex)
+# Check for agent CLI (OpenCode, Claude Code, Codex, or Copilot CLI)
 $hasOpenCode = Get-Command opencode -ErrorAction SilentlyContinue
 $hasClaude = Get-Command claude -ErrorAction SilentlyContinue
 $hasCodex = Get-Command codex -ErrorAction SilentlyContinue
-if (-not $hasOpenCode -and -not $hasClaude -and -not $hasCodex) {
-  Write-Error "OpenCode, Claude Code, or Codex is required but not installed. Install OpenCode: npm install -g opencode-ai. Install Claude Code: https://claude.ai/code. Install Codex: https://developers.openai.com/codex/"
+$hasCopilot = Get-Command copilot -ErrorAction SilentlyContinue
+if (-not $hasOpenCode -and -not $hasClaude -and -not $hasCodex -and -not $hasCopilot) {
+  Write-Error "OpenCode, Claude Code, Codex, or Copilot CLI is required but not installed. Install OpenCode: npm install -g opencode-ai. Install Claude Code: https://claude.ai/code. Install Codex: https://developers.openai.com/codex/. Install Copilot CLI: npm install -g @github/copilot"
   exit 1
 }
 
@@ -24,6 +25,8 @@ if (-not $hasOpenCode) {
     Write-Warning "OpenCode not found. Default agent is OpenCode. Use --agent claude-code or install OpenCode."
   } elseif ($hasCodex) {
     Write-Warning "OpenCode not found. Default agent is OpenCode. Use --agent codex or install OpenCode."
+  } elseif ($hasCopilot) {
+    Write-Warning "OpenCode not found. Default agent is OpenCode. Use --agent copilot or install OpenCode."
   }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -12,12 +12,13 @@ if ! command -v bun &> /dev/null; then
     exit 1
 fi
 
-# Check for agent CLI (OpenCode, Claude Code, or Codex)
-if ! command -v opencode &> /dev/null && ! command -v claude &> /dev/null && ! command -v codex &> /dev/null; then
-    echo "Error: OpenCode, Claude Code, or Codex is required but not installed."
+# Check for agent CLI (OpenCode, Claude Code, Codex, or Copilot CLI)
+if ! command -v opencode &> /dev/null && ! command -v claude &> /dev/null && ! command -v codex &> /dev/null && ! command -v copilot &> /dev/null; then
+    echo "Error: OpenCode, Claude Code, Codex, or Copilot CLI is required but not installed."
     echo "Install OpenCode: npm install -g opencode-ai"
     echo "Install Claude Code: https://claude.ai/code"
     echo "Install Codex: https://developers.openai.com/codex/"
+    echo "Install Copilot CLI: npm install -g @github/copilot"
     exit 1
 fi
 
@@ -27,6 +28,8 @@ if ! command -v opencode &> /dev/null; then
         echo "Use --agent claude-code or install OpenCode."
     elif command -v codex &> /dev/null; then
         echo "Use --agent codex or install OpenCode."
+    elif command -v copilot &> /dev/null; then
+        echo "Use --agent copilot or install OpenCode."
     fi
 fi
 


### PR DESCRIPTION
## Summary

Add `copilot` as a fourth agent type alongside `opencode`, `claude-code`, and `codex`. GitHub Copilot CLI is a full agentic coding tool with programmatic mode (`-p`), automatic permission bypass (`--allow-all`), model selection (`--model`), and non-interactive execution — architecturally equivalent to Claude Code and Codex for Ralph's purposes.

## Changes

### `ralph.ts`
- Extended `AgentType` union with `"copilot"`
- Added `copilot` entry to `AGENTS` record:
  - `-p` flag for prompt delivery (same pattern as `claude-code`)
  - `--model` forwarding when specified
  - `--allow-all` + `--no-ask-user` when `allowAllPermissions` is true
  - Environment passthrough (uses `GH_TOKEN`/`GITHUB_TOKEN` from env)
  - Provisional `parseToolOutput` regex (same pattern as `codex`, marked for empirical refinement)
- Updated `--agent` CLI validation to accept `"copilot"` with updated error message
- Updated help text to list `copilot` in available agents
- Added `--no-plugins` warning for `copilot` agent (no effect, like `claude-code` and `codex`)

### `README.md`
- Added Copilot CLI to header, description, and Supported Agents table
- Added Copilot CLI examples to Quick Start and agent usage sections
- Added full "Copilot CLI" section under Agent-Specific Notes with install prereqs, usage examples, and auth notes
- Updated `--agent` option description in Commands section

### `install.sh` / `install.ps1`
- Added `copilot` to agent CLI detection checks so installations with only Copilot CLI installed are accepted

## Verification

All verified locally with Copilot CLI v0.0.405:

| Test | Result |
|------|--------|
| `bun ralph.ts --help` shows `copilot` | ✅ |
| `bun ralph.ts "test" --agent invalid` error includes `copilot` | ✅ |
| `bun ralph.ts "test" --agent copilot --no-plugins` warns | ✅ |
| `bun ralph.ts "test" --agent copilot --no-allow-all` omits `--allow-all` | ✅ |
| `bun ralph.ts "test" --agent copilot --model gpt-5.2-codex` forwards model | ✅ |
| End-to-end: `--max-iterations 1` with real prompt — streams output, detects completion | ✅ |

## Design Decisions

- **Agent name:** `copilot` (matching the binary name)
- **Permission flags:** `--allow-all` (comprehensive: tools + paths + URLs) + `--no-ask-user` (prevents blocking on clarification questions in the loop)
- **No `--silent`:** Ralph needs to see tool output for streaming/parsing; users can pass `-- --silent` via extra flags if desired
- **Exit behavior:** Copilot CLI exits nonzero on LLM backend errors — already handled by the existing `exitCode !== 0` warning in the main loop
