### PR TITLE
Add custom prompt template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Options:
   --model MODEL            Model to use (agent-specific)
   --rotation LIST          Agent/model rotation for each iteration (comma-separated)
   --prompt-file, --file, -f  Read prompt content from a file
+  --prompt-template PATH   Use custom prompt template (see Custom Prompts)
   --no-stream              Buffer agent output and print at the end
   --verbose-tools          Print every tool line (disable compact tool summary)
   --no-plugins             Disable non-auth OpenCode plugins for this run (opencode only)
@@ -262,6 +263,44 @@ Example task file:
   - [ ] Create login page
   - [ ] Add JWT handling
 - [ ] Build dashboard UI
+```
+
+### Custom Prompt Templates
+
+You can fully customize the prompt sent to the agent using `--prompt-template`. This is useful for integrating with custom workflows or tools.
+
+```bash
+ralph "Build a REST API" --prompt-template ./my-template.md
+```
+
+**Available variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `{{iteration}}` | Current iteration number |
+| `{{max_iterations}}` | Maximum iterations (or "unlimited") |
+| `{{min_iterations}}` | Minimum iterations |
+| `{{prompt}}` | The user's task prompt |
+| `{{completion_promise}}` | Completion promise text (e.g., "COMPLETE") |
+| `{{task_promise}}` | Task promise text (for tasks mode) |
+| `{{context}}` | Additional context added mid-loop |
+| `{{tasks}}` | Task list content (for tasks mode) |
+
+**Example template (`my-template.md`):**
+
+```markdown
+# Iteration {{iteration}} / {{max_iterations}}
+
+## Task
+{{prompt}}
+
+## Instructions
+1. Check beads for current status
+2. Decide what to do next
+3. When the epic in beads is complete, output:
+   <promise>{{completion_promise}}</promise>
+
+{{context}}
 ```
 
 ### Monitoring & Control


### PR DESCRIPTION
## Summary
Adds `--prompt-template` flag to allow users to fully customize the prompt sent to the agent.

## Use Case
Users with custom workflows (like @maxim's beads system) can now define their own prompt structure instead of using Ralph's built-in instructions.

## Features
- `--prompt-template PATH` flag to specify a custom template file
- Template variables: `{{iteration}}`, `{{prompt}}`, `{{completion_promise}}`, `{{context}}`, `{{tasks}}`, etc.
- Template persists across loop restarts (saved in state)
- Full documentation in README

## Example

```markdown
# Iteration {{iteration}}

{{prompt}}

When done, output: <promise>{{completion_promise}}</promise>
```

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how prompts are constructed and persisted, which can affect loop behavior across iterations; however it is scoped to an opt-in flag and mostly involves file I/O and string substitution.
> 
> **Overview**
> Adds `--prompt-template` to the `ralph` CLI so users can provide a markdown/text template file that fully replaces the built-in prompt generation.
> 
> Implements template loading with variable substitution (iteration counters, promises, user prompt, injected context, and tasks content) and persists the template path in the saved loop state so it survives restarts/resumes. Documentation is updated in `README.md` with usage and a variable reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b12f569e2d3beb97eb001f5a859fb63d32bc089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->