### PR TITLE
Add --abort-promise flag for early loop exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Options:
   --min-iterations N       Minimum iterations before completion allowed (default: 1)
   --max-iterations N       Stop after N iterations (default: unlimited)
   --completion-promise T   Text that signals completion (default: COMPLETE)
+  --abort-promise TEXT     Phrase that signals early abort (e.g., precondition failed)
   --tasks, -t              Enable Tasks Mode for structured task tracking
   --task-promise T         Text that signals task completion (default: READY_FOR_NEXT_TASK)
   --model MODEL            Model to use (agent-specific)
@@ -282,6 +283,7 @@ ralph "Build a REST API" --prompt-template ./my-template.md
 | `{{min_iterations}}` | Minimum iterations |
 | `{{prompt}}` | The user's task prompt |
 | `{{completion_promise}}` | Completion promise text (e.g., "COMPLETE") |
+| `{{abort_promise}}` | Abort promise text (if configured) |
 | `{{task_promise}}` | Task promise text (for tasks mode) |
 | `{{context}}` | Additional context added mid-loop |
 | `{{tasks}}` | Task list content (for tasks mode) |


### PR DESCRIPTION
## Summary
Adds `--abort-promise` flag to allow agents to abort the loop early when preconditions fail.

## Use Case
From @yriveiro-autodoc in #17: When implementing specs with preconditions that aren't met, the agent should be able to abort without falsely claiming completion.

## Usage
```bash
ralph "Implement feature X" --abort-promise "PRECONDITION_FAILED"
```

When the agent outputs `<promise>PRECONDITION_FAILED</promise>`, Ralph:
1. Shows abort message
2. Clears state
3. Exits with code 1 (error)

## Also included
- `{{abort_promise}}` template variable for custom prompts
- Updated documentation

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new control-flow exit path in the main loop that clears state/history/context and exits non-zero when a configurable abort token is detected, which could prematurely terminate runs if misconfigured or matched accidentally.
> 
> **Overview**
> Adds a new `--abort-promise` CLI flag that lets an agent intentionally stop the Ralph loop early by emitting `<promise>…</promise>` with the configured abort text.
> 
> The loop now persists `abortPromise` in `RalphState`, supports `{{abort_promise}}` in custom prompt templates, detects the abort token in combined stdout/stderr each iteration, and on detection prints an abort summary, clears state/history/context, and exits with code `1`. Documentation is updated to describe the new flag and template variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 764f3ca767e84e439accc16b6fb79e483e59e250. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->