### PR TITLE
docs: add Relens community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@
   🏝️ <a href="https://github.com/Th0rgal/sandboxed.sh">sandboxed.sh</a> gives each task an isolated Linux workspace. Self-hosted. Git-backed.
 </p>
 
+<p align="center">
+  💬 <strong>Join the community:</strong> <a href="https://relens.ai/community">relens.ai/community</a>
+</p>
+
 ---
 
 ## Supported Agents


### PR DESCRIPTION
Add link to the Relens AI coding agents community for tips, tricks, and workflows sharing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding an external link; no runtime, security, or behavior impact.
> 
> **Overview**
> Adds a centered **community callout** to `README.md` linking to `https://relens.ai/community` for users to join the Relens AI coding agents community.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69ec8f3cdd31411e791e778e9a8e199a177fc69b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->