### PR TITLE
test: make SIGINT cleanup coverage deterministic

### DIFF
--- a/tests/fixtures/fake-opencode.ts
+++ b/tests/fixtures/fake-opencode.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bun
+
+console.log("fixture agent ready");
+
+const shutdown = () => {
+  process.exit(0);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+await new Promise(() => {});

--- a/tests/sigint-cleanup.test.ts
+++ b/tests/sigint-cleanup.test.ts
@@ -29,13 +29,13 @@ async function readStream(stream: ReadableStream<Uint8Array> | null, onText: (ch
   }
 }
 
-async function waitFor(check: () => boolean, timeoutMs: number, message: string) {
+async function waitFor(check: () => boolean, timeoutMs: number, message: () => string) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
     if (check()) return;
     await wait(50);
   }
-  throw new Error(message);
+  throw new Error(message());
 }
 
 function spawnRalph() {
@@ -94,7 +94,7 @@ describe("SIGINT cleanup", () => {
     await waitFor(
       () => run.getStdout().includes("⏳ working..."),
       5000,
-      `Timed out waiting for heartbeat.\nstdout:\n${run.getStdout()}\nstderr:\n${run.getStderr()}`,
+      () => `Timed out waiting for heartbeat.\nstdout:\n${run.getStdout()}\nstderr:\n${run.getStderr()}`,
     );
 
     run.proc.kill("SIGINT");

--- a/tests/sigint-cleanup.test.ts
+++ b/tests/sigint-cleanup.test.ts
@@ -1,77 +1,139 @@
-import { describe, expect, it, beforeEach } from 'bun:test';
-import { existsSync, unlinkSync } from 'fs';
-import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "fs";
+import { join } from "path";
 
-const stateDir = join(process.cwd(), '.ralph');
-const statePath = join(stateDir, 'ralph-loop.state.json');
-const questionsPath = join(stateDir, 'ralph-questions.json');
+const stateDir = join(process.cwd(), ".ralph");
+const statePath = join(stateDir, "ralph-loop.state.json");
+const questionsPath = join(stateDir, "ralph-questions.json");
+const fakeOpencodePath = join(process.cwd(), "tests", "fixtures", "fake-opencode.ts");
 
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('SIGINT Cleanup', () => {
+async function readStream(stream: ReadableStream<Uint8Array> | null, onText: (chunk: string) => void) {
+  if (!stream) return;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      onText(decoder.decode(value, { stream: true }));
+    }
+    const flushed = decoder.decode();
+    if (flushed) onText(flushed);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function waitFor(check: () => boolean, timeoutMs: number, message: string) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (check()) return;
+    await wait(50);
+  }
+  throw new Error(message);
+}
+
+function spawnRalph() {
+  const proc = Bun.spawn({
+    cmd: ["bun", "run", "ralph.ts", "wait for SIGINT", "--max-iterations", "1"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      RALPH_OPENCODE_BINARY: fakeOpencodePath,
+    },
+  });
+
+  let stdout = "";
+  let stderr = "";
+  const stdoutDone = readStream(proc.stdout, chunk => {
+    stdout += chunk;
+  });
+  const stderrDone = readStream(proc.stderr, chunk => {
+    stderr += chunk;
+  });
+
+  return {
+    proc,
+    getStdout: () => stdout,
+    getStderr: () => stderr,
+    done: () => Promise.all([stdoutDone, stderrDone]),
+  };
+}
+
+describe("SIGINT cleanup", () => {
   beforeEach(() => {
     [statePath, questionsPath].forEach(path => {
       if (existsSync(path)) {
-        try { unlinkSync(path); } catch {}
+        try {
+          unlinkSync(path);
+        } catch {}
       }
     });
   });
 
-  it('stops heartbeat timer on SIGINT', async () => {
-    const proc = Bun.spawn({
-      cmd: ['bun', 'run', 'ralph.ts', 'sleep 5', '--max-iterations', '1'],
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: { ...process.env, NODE_ENV: 'test' }
+  afterEach(() => {
+    [statePath, questionsPath].forEach(path => {
+      if (existsSync(path)) {
+        try {
+          unlinkSync(path);
+        } catch {}
+      }
     });
-
-    await wait(1500);
-    
-    // Read current output
-    const reader = proc.stdout.getReader();
-    const { value } = await reader.read();
-    const text = new TextDecoder().decode(value);
-    reader.releaseLock();
-    
-    const heartbeatCount = (text.match(/⏳ working\.\.\./g) || []).length;
-    expect(heartbeatCount).toBeGreaterThan(0);
-
-    proc.kill('SIGINT');
-    const exitCode = await proc.exited;
-    expect(exitCode).toBeGreaterThanOrEqual(0);
   });
 
-  it('clears state on SIGINT', async () => {
-    const proc = Bun.spawn({
-      cmd: ['bun', 'run', 'ralph.ts', 'echo test', '--max-iterations', '1'],
-      stdout: 'pipe',
-      env: { ...process.env, NODE_ENV: 'test' }
-    });
+  it("stops heartbeat output after SIGINT", async () => {
+    const run = spawnRalph();
 
-    await wait(500);
-    proc.kill('SIGINT');
-    await proc.exited;
-    
-    // State should be cleared after SIGINT
+    await waitFor(
+      () => run.getStdout().includes("⏳ working..."),
+      5000,
+      `Timed out waiting for heartbeat.\nstdout:\n${run.getStdout()}\nstderr:\n${run.getStderr()}`,
+    );
+
+    run.proc.kill("SIGINT");
+    const exitCode = await run.proc.exited;
+    await run.done();
+
+    expect(exitCode).toBe(0);
+
+    const stdout = run.getStdout();
+    const stopMarker = "Gracefully stopping Ralph loop...";
+    expect(stdout).toContain(stopMarker);
+    expect(stdout).toContain("Loop cancelled.");
+
+    const shutdownTail = stdout.split(stopMarker)[1] ?? "";
+    expect(shutdownTail).not.toContain("⏳ working...");
+  });
+
+  it("clears state on SIGINT", async () => {
+    const run = spawnRalph();
+
+    await wait(300);
+    run.proc.kill("SIGINT");
+    await run.proc.exited;
+    await run.done();
+
     expect(existsSync(statePath)).toBe(false);
   });
 
-  it('handles double SIGINT (force stop)', async () => {
-    const proc = Bun.spawn({
-      cmd: ['bun', 'run', 'ralph.ts', 'sleep 10', '--max-iterations', '1'],
-      stdout: 'pipe',
-      env: { ...process.env, NODE_ENV: 'test' }
-    });
+  it("handles double SIGINT", async () => {
+    const run = spawnRalph();
 
-    await wait(500);
-    proc.kill('SIGINT');
-    await wait(100);
-    proc.kill('SIGINT');
+    await wait(300);
+    run.proc.kill("SIGINT");
+    await wait(50);
+    run.proc.kill("SIGINT");
 
-    const exitCode = await proc.exited;
-    // Either force stop (1) or normal stop (0) is acceptable
+    const exitCode = await run.proc.exited;
+    await run.done();
+
     expect([0, 1]).toContain(exitCode);
   });
 });

--- a/tests/sigint-cleanup.test.ts
+++ b/tests/sigint-cleanup.test.ts
@@ -67,6 +67,14 @@ function spawnRalph() {
   };
 }
 
+async function waitForRalphReady(run: ReturnType<typeof spawnRalph>) {
+  await waitFor(
+    () => existsSync(statePath) && run.getStdout().includes("fixture agent ready"),
+    5000,
+    () => `Timed out waiting for Ralph startup.\nstdout:\n${run.getStdout()}\nstderr:\n${run.getStderr()}`,
+  );
+}
+
 describe("SIGINT cleanup", () => {
   beforeEach(() => {
     [statePath, questionsPath].forEach(path => {
@@ -115,7 +123,7 @@ describe("SIGINT cleanup", () => {
   it("clears state on SIGINT", async () => {
     const run = spawnRalph();
 
-    await wait(300);
+    await waitForRalphReady(run);
     run.proc.kill("SIGINT");
     await run.proc.exited;
     await run.done();
@@ -126,7 +134,7 @@ describe("SIGINT cleanup", () => {
   it("handles double SIGINT", async () => {
     const run = spawnRalph();
 
-    await wait(300);
+    await waitForRalphReady(run);
     run.proc.kill("SIGINT");
     await wait(50);
     run.proc.kill("SIGINT");


### PR DESCRIPTION
## Summary
- replace the SIGINT tests' dependency on a real OpenCode install with a local fixture binary
- assert shutdown output does not emit heartbeat messages after SIGINT
- keep the state cleanup and double-SIGINT coverage, but make both tests deterministic

## Why
PR #62 merged a runtime fix, but its new tests were not reliable because they exited early when  was unavailable and did not actually verify that heartbeats stopped after shutdown.

## Verification
- bun test v1.3.9 (cf6cdbbb)
- bun test v1.3.9 (cf6cdbbb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to tests by replacing external OpenCode dependency with a local fixture and improving process/stream synchronization, with no production logic modifications.
> 
> **Overview**
> Makes the SIGINT cleanup test suite deterministic by introducing a local `tests/fixtures/fake-opencode.ts` binary and forcing Ralph to use it via `RALPH_OPENCODE_BINARY`, removing reliance on a real OpenCode install.
> 
> Refactors the SIGINT tests to use a shared spawn helper with streaming stdout/stderr capture plus `waitFor` polling, adds `afterEach` cleanup, and strengthens assertions to verify shutdown emits the expected stop messages and **does not print further `⏳ working...` heartbeats after** `Gracefully stopping Ralph loop...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bc9f4b96f31dbe86c51cdd9478704fd9e906405. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->