### PR TITLE
fix: completion promise detection for Claude Code JSON stream

### DIFF
--- a/ralph.ts
+++ b/ralph.ts
@@ -2146,9 +2146,23 @@ async function runRalphLoop(): Promise<void> {
       }
 
       const combinedOutput = `${result}\n${stderr}`;
-      const completionSignalDetected = checkCompletion(result, completionPromise);
-      const abortDetected = abortPromise ? checkCompletion(result, abortPromise) : false;
-      const taskCompletionDetected = tasksMode ? checkCompletion(result, taskPromise) : false;
+
+      // Claude Code outputs JSON stream (one JSON object per line), not plain text.
+      // The completion promise regex won't match raw JSON. Extract display text first.
+      let completionCheckText = result;
+      if (agentConfig.type === "claude-code") {
+        const displayLines: string[] = [];
+        for (const rawLine of result.split(/\r?\n/)) {
+          for (const dl of extractClaudeStreamDisplayLines(rawLine)) {
+            if (dl.trim()) displayLines.push(dl.trim());
+          }
+        }
+        completionCheckText = displayLines.join("\n");
+      }
+
+      const completionSignalDetected = checkCompletion(completionCheckText, completionPromise);
+      const abortDetected = abortPromise ? checkCompletion(completionCheckText, abortPromise) : false;
+      const taskCompletionDetected = tasksMode ? checkCompletion(completionCheckText, taskPromise) : false;
 
       let completionDetected = completionSignalDetected;
       if (tasksMode && completionSignalDetected) {


### PR DESCRIPTION
## Problem

When using `--agent claude-code`, the completion promise detection always fails. Ralph never detects `<promise>COMPLETE</promise>` even though the agent correctly outputs it.

I was running into this where ralph just kept looping because it never detected the completion signal.

## Root Cause

Claude Code's stdout is a JSON stream (one JSON object per line), not plain text. When the agent outputs `<promise>COMPLETE</promise>`, the actual stdout line is:

```json
{"type":"assistant","message":{"content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}
```

But `checkCompletion()` runs the regex directly on this raw JSON string, so the pattern `^<promise>\s*COMPLETE\s*</promise>$` never matches because the line starts with `{`.

The function `extractClaudeStreamDisplayLines()` already exists and correctly parses Claude Code JSON into display text - but it was only used for terminal output display, not for completion detection.

## Fix

Before calling `checkCompletion()`, extract the display text from the JSON stream when using Claude Code:

```typescript
let completionCheckText = result;
if (agentConfig.type === "claude-code") {
  const displayLines: string[] = [];
  for (const rawLine of result.split(/\r?\n/)) {
    for (const dl of extractClaudeStreamDisplayLines(rawLine)) {
      if (dl.trim()) displayLines.push(dl.trim());
    }
  }
  completionCheckText = displayLines.join("\n");
}
```

This reuses the existing `extractClaudeStreamDisplayLines` function (line 1487) that is already battle-tested for the terminal display path. The same extraction is applied to completion, abort, and task completion checks.

For non-Claude agents (opencode, codex, copilot), `completionCheckText` stays as the raw `result` so their behavior is unchanged.

Closes #67