### PR TITLE
fix(windows): use opencode.cmd when spawning OpenCode on win32

### DIFF
--- a/ralph.ts
+++ b/ralph.ts
@@ -2126,7 +2126,8 @@ async function runRalphLoop(): Promise<void> {
 
       // Run agent using spawn for better argument handling
       // stdin is inherited so users can respond to permission prompts if needed
-      currentProc = Bun.spawn([agentConfig.command, ...cmdArgs], {
+      const command = process.platform === "win32" && agentConfig.command === "opencode"? "opencode.cmd": agentConfig.command;
+      currentProc = Bun.spawn([command, ...cmdArgs], {
         cwd: process.cwd(),
         env,
         stdin: "inherit",


### PR DESCRIPTION
## Summary
Fix a Windows-specific issue where Ralph fails to launch OpenCode via `Bun.spawn()`.

## Problem
On Windows, `opencode` may work from an interactive shell, but Ralph can still fail with:

```txt
❌ Error in iteration 5: 2045 |         allowAllPermissions: allowAllPermissions,
2046 |       });
2047 |
2048 |       // Run agent using spawn for better argument handling
2049 |       // stdin is inherited so users can respond to permission prompts if needed
2050 |       currentProc = Bun.spawn([agentConfig.command, ...cmdArgs], {
                               ^
ENOENT: no such file or directory, uv_spawn 'opencode'
    path: "opencode",
 syscall: "uv_spawn",
   errno: -4058,
    code: "ENOENT"

      at runRalphLoop (xxxx\node_modules\@th0rgal\ralph-wiggum\ralph.ts:2050:25)

Continuing to next iteration...
```


## Root cause
In some Windows environments, the executable entry point is exposed through the `opencode.cmd` shim.
Shells can resolve this automatically, but direct spawning with `Bun.spawn()` may not.

## Fix
When running on `win32`, if the configured command is `opencode`, use `opencode.cmd` instead.

## Validation
- Verified `opencode --version` works in the terminal
- Verified Ralph can launch OpenCode successfully on Windows
- Confirmed the previous `uv_spawn 'opencode'` failure no longer occurs