### PR TITLE
fix: normalize agent stream completion handling

### DIFF
--- a/completion.ts
+++ b/completion.ts
@@ -56,3 +56,160 @@ export function tasksMarkdownAllComplete(tasksMarkdown: string): boolean {
 
   return sawTask;
 }
+
+function addNonEmptyTextLines(lines: string[], value: unknown): void {
+  if (typeof value !== "string") return;
+  for (const splitLine of value.split(/\r?\n/)) {
+    const trimmed = splitLine.trim();
+    if (trimmed) lines.push(trimmed);
+  }
+}
+
+export function extractClaudeStreamDisplayLines(rawLine: string): string[] {
+  const cleanLine = stripAnsi(rawLine).trim();
+  if (!cleanLine.startsWith("{")) {
+    return [rawLine];
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(cleanLine);
+  } catch {
+    return [rawLine];
+  }
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+
+  const lines: string[] = [];
+  const addContentText = (content: unknown) => {
+    if (typeof content === "string") {
+      addNonEmptyTextLines(lines, content);
+      return;
+    }
+    if (!Array.isArray(content)) return;
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const blockRecord = block as Record<string, unknown>;
+      if (blockRecord.type === "tool_use") continue;
+      addNonEmptyTextLines(lines, blockRecord.text);
+      addNonEmptyTextLines(lines, blockRecord.thinking);
+      if (typeof blockRecord.content === "string") {
+        addNonEmptyTextLines(lines, blockRecord.content);
+      }
+    }
+  };
+
+  const payloadRecord = payload as Record<string, unknown>;
+  const payloadType = typeof payloadRecord.type === "string" ? payloadRecord.type : "";
+  if (payloadType === "assistant") {
+    if (payloadRecord.message && typeof payloadRecord.message === "object") {
+      const message = payloadRecord.message as Record<string, unknown>;
+      addContentText(message.content);
+    }
+    if (payloadRecord.delta && typeof payloadRecord.delta === "object") {
+      const delta = payloadRecord.delta as Record<string, unknown>;
+      addNonEmptyTextLines(lines, delta.text);
+      addNonEmptyTextLines(lines, delta.thinking);
+      addNonEmptyTextLines(lines, delta.content);
+    }
+  } else if (payloadType === "result") {
+    addNonEmptyTextLines(lines, payloadRecord.result);
+  } else if (payloadType === "error") {
+    if (payloadRecord.error && typeof payloadRecord.error === "object") {
+      const error = payloadRecord.error as Record<string, unknown>;
+      addNonEmptyTextLines(lines, error.message);
+    } else {
+      addNonEmptyTextLines(lines, payloadRecord.error);
+    }
+  }
+
+  return lines;
+}
+
+export function extractCursorAgentStreamDisplayLines(rawLine: string): string[] {
+  const cleanLine = stripAnsi(rawLine).trim();
+  if (!cleanLine.startsWith("{")) {
+    return [rawLine];
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(cleanLine);
+  } catch {
+    return [rawLine];
+  }
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+
+  const lines: string[] = [];
+  const p = payload as Record<string, unknown>;
+  const payloadType = typeof p.type === "string" ? p.type : "";
+
+  if (payloadType === "assistant") {
+    if (p.message && typeof p.message === "object") {
+      const msg = p.message as Record<string, unknown>;
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block && typeof block === "object") {
+            addNonEmptyTextLines(lines, (block as Record<string, unknown>).text);
+          }
+        }
+      }
+    }
+  } else if (payloadType === "tool_call") {
+    const tc = p.tool_call as Record<string, unknown> | undefined;
+    if (tc && typeof tc === "object") {
+      const toolKey = Object.keys(tc).find((k: string) => k.endsWith("ToolCall"));
+      if (toolKey) {
+        const toolName = toolKey.replace("ToolCall", "");
+        const toolData = tc[toolKey] as Record<string, unknown> | undefined;
+        if (p.subtype === "started" && toolData?.args && typeof toolData.args === "object") {
+          const args = toolData.args as Record<string, unknown>;
+          if (toolName === "shell" && typeof args.command === "string") {
+            lines.push(`[SHELL] ${args.command}`);
+          } else if (typeof args.path === "string") {
+            lines.push(`[${toolName.toUpperCase()}] ${args.path}`);
+          } else if (typeof args.pattern === "string") {
+            lines.push(`[${toolName.toUpperCase()}] ${args.pattern}`);
+          } else {
+            lines.push(`[${toolName.toUpperCase()}]`);
+          }
+        }
+      }
+    }
+  } else if (payloadType === "result") {
+    addNonEmptyTextLines(lines, p.result);
+    if (p.subtype && typeof p.subtype === "string") {
+      lines.push(`[RESULT] ${p.subtype}`);
+    }
+  } else if (payloadType === "error") {
+    if (p.error && typeof p.error === "object") {
+      addNonEmptyTextLines(lines, (p.error as Record<string, unknown>).message);
+    } else {
+      addNonEmptyTextLines(lines, p.error);
+    }
+  }
+
+  return lines;
+}
+
+export function extractAgentCompletionText(output: string, agentType: string): string {
+  const extractStreamLines = agentType === "claude-code"
+    ? extractClaudeStreamDisplayLines
+    : agentType === "cursor-agent"
+    ? extractCursorAgentStreamDisplayLines
+    : null;
+
+  if (!extractStreamLines) return output;
+
+  const displayLines: string[] = [];
+  for (const rawLine of output.split(/\r?\n/)) {
+    for (const line of extractStreamLines(rawLine)) {
+      if (line.trim()) displayLines.push(line.trim());
+    }
+  }
+
+  return displayLines.join("\n");
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0rgal/ralph-wiggum",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Ralph Wiggum technique for iterative AI development loops with multi-agent support",
   "main": "bin/ralph.js",
   "bin": {

--- a/ralph.ts
+++ b/ralph.ts
@@ -18,7 +18,7 @@ import {
   tasksMarkdownAllComplete,
 } from "./completion";
 
-const VERSION = "1.2.2";
+const VERSION = "1.3.0";
 
 // Detect Windows platform for command resolution
 const IS_WINDOWS = process.platform === "win32";

--- a/ralph.ts
+++ b/ralph.ts
@@ -9,7 +9,14 @@
 import { $ } from "bun";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "fs";
 import { join } from "path";
-import { checkTerminalPromise, stripAnsi, tasksMarkdownAllComplete } from "./completion";
+import {
+  checkTerminalPromise,
+  extractAgentCompletionText,
+  extractClaudeStreamDisplayLines,
+  extractCursorAgentStreamDisplayLines,
+  stripAnsi,
+  tasksMarkdownAllComplete,
+} from "./completion";
 
 const VERSION = "1.2.2";
 
@@ -196,7 +203,7 @@ function createAgentConfig(json: JsonAgentConfig): AgentConfig {
 
   return {
     type: json.type,
-    command: resolveCommand(json.command, process.env[`RALPH_${json.type.toUpperCase()}_BINARY`]),
+    command: resolveCommand(json.command, process.env[getAgentBinaryEnvName(json.type)]),
     buildArgs: ARGS_TEMPLATES[argsTemplate] || ARGS_TEMPLATES["default"],
     buildEnv: ENV_TEMPLATES[envTemplate] || ENV_TEMPLATES["default"],
     parseToolOutput: PARSE_PATTERNS[parsePattern] || PARSE_PATTERNS["default"],
@@ -217,20 +224,19 @@ function getDefaultConfig(): RalphConfig {
   };
 }
 
+function getAgentBinaryEnvName(agentType: string): string {
+  return `RALPH_${agentType.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_BINARY`;
+}
+
 /**
  * Resolve a command for cross-platform compatibility.
  * On Windows, many npm-installed CLIs require the .cmd extension.
  */
 function resolveCommand(cmd: string, envOverride?: string): string {
   if (envOverride) return envOverride;
-  // On Windows, try the .cmd version first if the base command isn't found
-  if (IS_WINDOWS) {
-    const cmdPath = Bun.which(cmd);
-    if (!cmdPath) {
-      const cmdWithExt = `${cmd}.cmd`;
-      const cmdExtPath = Bun.which(cmdWithExt);
-      if (cmdExtPath) return cmdWithExt;
-    }
+  if (IS_WINDOWS && !/[\\/]/.test(cmd) && !/\.(cmd|exe|bat)$/i.test(cmd)) {
+    const cmdWithExt = `${cmd}.cmd`;
+    if (Bun.which(cmdWithExt)) return cmdWithExt;
   }
   return cmd;
 }
@@ -1532,151 +1538,6 @@ function detectModelNotFoundError(output: string): boolean {
          output.includes("No model configured");
 }
 
-function extractClaudeStreamDisplayLines(rawLine: string): string[] {
-  const cleanLine = stripAnsi(rawLine).trim();
-  if (!cleanLine.startsWith("{")) {
-    return [rawLine];
-  }
-
-  let payload: unknown;
-  try {
-    payload = JSON.parse(cleanLine);
-  } catch {
-    return [rawLine];
-  }
-  if (!payload || typeof payload !== "object") {
-    return [];
-  }
-
-  const lines: string[] = [];
-  const addText = (value: unknown) => {
-    if (typeof value !== "string") return;
-    for (const splitLine of value.split(/\r?\n/)) {
-      const trimmed = splitLine.trim();
-      if (trimmed) lines.push(trimmed);
-    }
-  };
-  const addContentText = (content: unknown) => {
-    if (typeof content === "string") {
-      addText(content);
-      return;
-    }
-    if (!Array.isArray(content)) return;
-    for (const block of content) {
-      if (!block || typeof block !== "object") continue;
-      const blockRecord = block as Record<string, unknown>;
-      if (blockRecord.type === "tool_use") continue;
-      addText(blockRecord.text);
-      addText(blockRecord.thinking);
-      if (typeof blockRecord.content === "string") {
-        addText(blockRecord.content);
-      }
-    }
-  };
-
-  const payloadRecord = payload as Record<string, unknown>;
-  const payloadType = typeof payloadRecord.type === "string" ? payloadRecord.type : "";
-  if (payloadType === "assistant") {
-    if (payloadRecord.message && typeof payloadRecord.message === "object") {
-      const message = payloadRecord.message as Record<string, unknown>;
-      addContentText(message.content);
-    }
-    if (payloadRecord.delta && typeof payloadRecord.delta === "object") {
-      const delta = payloadRecord.delta as Record<string, unknown>;
-      addText(delta.text);
-      addText(delta.thinking);
-      addText(delta.content);
-    }
-  } else if (payloadType === "result") {
-    addText(payloadRecord.result);
-  } else if (payloadType === "error") {
-    if (payloadRecord.error && typeof payloadRecord.error === "object") {
-      const error = payloadRecord.error as Record<string, unknown>;
-      addText(error.message);
-    } else {
-      addText(payloadRecord.error);
-    }
-  }
-
-  return lines;
-}
-
-function extractCursorAgentStreamDisplayLines(rawLine: string): string[] {
-  const cleanLine = stripAnsi(rawLine).trim();
-  if (!cleanLine.startsWith("{")) {
-    return [rawLine];
-  }
-
-  let payload: unknown;
-  try {
-    payload = JSON.parse(cleanLine);
-  } catch {
-    return [rawLine];
-  }
-  if (!payload || typeof payload !== "object") {
-    return [];
-  }
-
-  const lines: string[] = [];
-  const addText = (value: unknown) => {
-    if (typeof value !== "string") return;
-    for (const splitLine of value.split(/\r?\n/)) {
-      const trimmed = splitLine.trim();
-      if (trimmed) lines.push(trimmed);
-    }
-  };
-
-  const p = payload as Record<string, unknown>;
-  const payloadType = typeof p.type === "string" ? p.type : "";
-
-  if (payloadType === "assistant") {
-    if (p.message && typeof p.message === "object") {
-      const msg = p.message as Record<string, unknown>;
-      if (Array.isArray(msg.content)) {
-        for (const block of msg.content) {
-          if (block && typeof block === "object") {
-            addText((block as Record<string, unknown>).text);
-          }
-        }
-      }
-    }
-  } else if (payloadType === "tool_call") {
-    const tc = p.tool_call as Record<string, unknown> | undefined;
-    if (tc && typeof tc === "object") {
-      const toolKey = Object.keys(tc).find((k: string) => k.endsWith("ToolCall"));
-      if (toolKey) {
-        const toolName = toolKey.replace("ToolCall", "");
-        const toolData = tc[toolKey] as Record<string, unknown> | undefined;
-        if (p.subtype === "started" && toolData?.args && typeof toolData.args === "object") {
-          const args = toolData.args as Record<string, unknown>;
-          if (toolName === "shell" && typeof args.command === "string") {
-            lines.push(`[SHELL] ${args.command}`);
-          } else if (typeof args.path === "string") {
-            lines.push(`[${toolName.toUpperCase()}] ${args.path}`);
-          } else if (typeof args.pattern === "string") {
-            lines.push(`[${toolName.toUpperCase()}] ${args.pattern}`);
-          } else {
-            lines.push(`[${toolName.toUpperCase()}]`);
-          }
-        }
-      }
-    }
-  } else if (payloadType === "result") {
-    addText(p.result);
-    if (p.subtype && typeof p.subtype === "string") {
-      lines.push(`[RESULT] ${p.subtype}`);
-    }
-  } else if (payloadType === "error") {
-    if (p.error && typeof p.error === "object") {
-      addText((p.error as Record<string, unknown>).message);
-    } else {
-      addText(p.error);
-    }
-  }
-
-  return lines;
-}
-
 function formatDuration(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
   const hours = Math.floor(totalSeconds / 3600);
@@ -2241,8 +2102,7 @@ async function runRalphLoop(): Promise<void> {
 
       // Run agent using spawn for better argument handling
       // stdin is inherited so users can respond to permission prompts if needed
-      const command = process.platform === "win32" && agentConfig.command === "opencode"? "opencode.cmd": agentConfig.command;
-      currentProc = Bun.spawn([command, ...cmdArgs], {
+      currentProc = Bun.spawn([agentConfig.command, ...cmdArgs], {
         cwd: process.cwd(),
         env,
         stdin: "inherit",
@@ -2300,21 +2160,7 @@ async function runRalphLoop(): Promise<void> {
       const combinedOutput = `${result}\n${stderr}`;
 
       // For agents using stream-json, extract display text before checking completion
-      let completionCheckText = result;
-      const extractStreamLines = agentConfig.type === "claude-code"
-        ? extractClaudeStreamDisplayLines
-        : agentConfig.type === "cursor-agent"
-        ? extractCursorAgentStreamDisplayLines
-        : null;
-      if (extractStreamLines) {
-        const displayLines: string[] = [];
-        for (const rawLine of result.split(/\r?\n/)) {
-          for (const dl of extractStreamLines(rawLine)) {
-            if (dl.trim()) displayLines.push(dl.trim());
-          }
-        }
-        completionCheckText = displayLines.join("\n");
-      }
+      const completionCheckText = extractAgentCompletionText(result, agentConfig.type);
 
       const completionSignalDetected = checkCompletion(completionCheckText, completionPromise);
       const abortDetected = abortPromise ? checkCompletion(completionCheckText, abortPromise) : false;

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { checkTerminalPromise, getLastNonEmptyLine, tasksMarkdownAllComplete } from "../completion";
+import {
+  checkTerminalPromise,
+  extractAgentCompletionText,
+  extractClaudeStreamDisplayLines,
+  extractCursorAgentStreamDisplayLines,
+  getLastNonEmptyLine,
+  tasksMarkdownAllComplete,
+} from "../completion";
 
 describe("checkTerminalPromise", () => {
   it("detects completion when promise tag is the final non-empty line", () => {
@@ -69,5 +76,54 @@ describe("tasksMarkdownAllComplete", () => {
     ].join("\n");
 
     expect(tasksMarkdownAllComplete(markdown)).toBe(true);
+  });
+});
+
+describe("agent stream output extraction", () => {
+  it("extracts Claude Code assistant text from JSON stream lines", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "done\n<promise>COMPLETE</promise>" }],
+      },
+    });
+
+    expect(extractClaudeStreamDisplayLines(line)).toEqual(["done", "<promise>COMPLETE</promise>"]);
+  });
+
+  it("uses extracted Claude Code text for completion detection", () => {
+    const output = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Implemented changes." }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "<promise>COMPLETE</promise>" }],
+        },
+      }),
+    ].join("\n");
+
+    expect(checkTerminalPromise(output, "COMPLETE")).toBe(false);
+    expect(checkTerminalPromise(extractAgentCompletionText(output, "claude-code"), "COMPLETE")).toBe(true);
+  });
+
+  it("extracts Cursor Agent assistant text from JSON stream lines", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "ready\n<promise>COMPLETE</promise>" }],
+      },
+    });
+
+    expect(extractCursorAgentStreamDisplayLines(line)).toEqual(["ready", "<promise>COMPLETE</promise>"]);
+  });
+
+  it("leaves non-streaming agents unchanged for completion detection", () => {
+    const output = "Finished\n<promise>COMPLETE</promise>";
+    expect(extractAgentCompletionText(output, "opencode")).toBe(output);
   });
 });


### PR DESCRIPTION
## Summary
- apply the Claude Code JSON stream completion fix from #69 on top of the merged Cursor Agent support
- share stream-json display extraction through completion helpers so Claude Code and Cursor Agent completion checks use the same path as terminal display
- make custom agent binary env var names normalize hyphenated agent types, and resolve Windows `.cmd` shims for every bare command instead of only `opencode`
- add regression tests for Claude Code and Cursor Agent stream completion extraction

## Review notes
- #69 is still conflicting with current `master`; this PR carries its relevant fix with tests.
- #72 and #73 have already been merged into `master`.

## Tests
- `bun test`
- `bun build ralph.ts --outfile /tmp/ralph-test.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core loop completion detection and cross-platform command resolution; small logic changes could cause premature/non-detection of completion or command launch issues for some agent setups.
> 
> **Overview**
> Fixes completion-promise detection for stream-json agents by extracting assistant-visible text from Claude Code and Cursor Agent JSON lines and using that normalized text for loop completion checks via new `extractAgentCompletionText` (moved/shared in `completion.ts`).
> 
> Improves agent command resolution by normalizing custom agent binary env var names for hyphenated types (e.g. `RALPH_CURSOR_AGENT_BINARY`) and by resolving Windows `.cmd` shims for any bare command (removing the `opencode`-only workaround). Adds tests covering Claude/Cursor stream extraction and completion detection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9929b287b5839343d7dd5e31283d0f033228e0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->