### PR TITLE
fix: completion promise detection with stream-json output format

### DIFF
--- a/completion.ts
+++ b/completion.ts
@@ -2,7 +2,7 @@
  * Completion detection helpers used by the Ralph loop.
  */
 
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const ANSI_PATTERN = /\[[0-9;]*m/g;
 
 export function stripAnsi(input: string): string {
   return input.replace(ANSI_PATTERN, "");
@@ -35,6 +35,17 @@ export function checkTerminalPromise(output: string, promise: string): boolean {
   const escapedPromise = escapeRegex(promise);
   const pattern = new RegExp(`^<promise>\\s*${escapedPromise}\\s*</promise>$`, "i");
   return pattern.test(lastLine);
+}
+
+/**
+ * Searches the entire output for the promise tag on its own line.
+ * This is a fallback for stream-json mode where the promise tag may appear
+ * inside JSON values and not as the final non-empty line of the raw output.
+ */
+export function containsPromiseTag(output: string, promise: string): boolean {
+  const escapedPromise = escapeRegex(promise);
+  const pattern = new RegExp(`<promise>\\s*${escapedPromise}\\s*</promise>`, "i");
+  return pattern.test(stripAnsi(output));
 }
 
 /**
@@ -112,6 +123,16 @@ export function extractClaudeStreamDisplayLines(rawLine: string): string[] {
       addNonEmptyTextLines(lines, delta.text);
       addNonEmptyTextLines(lines, delta.thinking);
       addNonEmptyTextLines(lines, delta.content);
+    }
+  } else if (payloadType === "stream_event") {
+    if (payloadRecord.event && typeof payloadRecord.event === "object") {
+      const event = payloadRecord.event as Record<string, unknown>;
+      if (event.delta && typeof event.delta === "object") {
+        const delta = event.delta as Record<string, unknown>;
+        if (delta.type === "text_delta" && typeof delta.text === "string") {
+          addNonEmptyTextLines(lines, delta.text);
+        }
+      }
     }
   } else if (payloadType === "result") {
     addNonEmptyTextLines(lines, payloadRecord.result);

--- a/ralph.ts
+++ b/ralph.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "fs
 import { join } from "path";
 import {
   checkTerminalPromise,
+  containsPromiseTag,
   extractAgentCompletionText,
   extractClaudeStreamDisplayLines,
   extractCursorAgentStreamDisplayLines,
@@ -1516,10 +1517,15 @@ Unable to read .ralph/ralph-tasks.md
 }
 
 /**
- * Check if output contains a completion promise as the final non-empty line.
+ * Check if output contains a completion promise.
+ * First checks if the promise tag is the final non-empty line (strict mode).
+ * Falls back to a full-text search of the raw output for stream-json agents
+ * where the promise may appear inside JSON values rather than as a standalone line.
  */
-function checkCompletion(output: string, promise: string): boolean {
-  return checkTerminalPromise(output, promise);
+function checkCompletion(output: string, promise: string, rawOutput?: string): boolean {
+  if (checkTerminalPromise(output, promise)) return true;
+  if (rawOutput && containsPromiseTag(rawOutput, promise)) return true;
+  return false;
 }
 
 function detectPlaceholderPluginError(output: string): boolean {
@@ -2162,9 +2168,9 @@ async function runRalphLoop(): Promise<void> {
       // For agents using stream-json, extract display text before checking completion
       const completionCheckText = extractAgentCompletionText(result, agentConfig.type);
 
-      const completionSignalDetected = checkCompletion(completionCheckText, completionPromise);
-      const abortDetected = abortPromise ? checkCompletion(completionCheckText, abortPromise) : false;
-      const taskCompletionDetected = tasksMode ? checkCompletion(completionCheckText, taskPromise) : false;
+      const completionSignalDetected = checkCompletion(completionCheckText, completionPromise, result);
+      const abortDetected = abortPromise ? checkCompletion(completionCheckText, abortPromise, result) : false;
+      const taskCompletionDetected = tasksMode ? checkCompletion(completionCheckText, taskPromise, result) : false;
 
       let completionDetected = completionSignalDetected;
       if (tasksMode && completionSignalDetected) {

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   checkTerminalPromise,
+  containsPromiseTag,
   extractAgentCompletionText,
   extractClaudeStreamDisplayLines,
   extractCursorAgentStreamDisplayLines,
@@ -41,6 +42,25 @@ describe("checkTerminalPromise", () => {
   it("accepts flexible whitespace inside promise tags", () => {
     const output = "<promise>   COMPLETE   </promise>";
     expect(checkTerminalPromise(output, "COMPLETE")).toBe(true);
+  });
+});
+
+describe("containsPromiseTag", () => {
+  it("finds promise tag anywhere in plain text", () => {
+    expect(containsPromiseTag("Some text\n<promise>COMPLETE</promise>\nMore text", "COMPLETE")).toBe(true);
+  });
+
+  it("finds promise tag inside JSON value", () => {
+    const output = '{"type":"text","text":"<promise>COMPLETE</promise>\\n"}{"type":"tool_summary","tools":{}}';
+    expect(containsPromiseTag(output, "COMPLETE")).toBe(true);
+  });
+
+  it("does not match a different promise", () => {
+    expect(containsPromiseTag("<promise>COMPLETE</promise>", "OTHER")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(containsPromiseTag("<promise>complete</promise>", "COMPLETE")).toBe(true);
   });
 });
 
@@ -91,6 +111,32 @@ describe("agent stream output extraction", () => {
     expect(extractClaudeStreamDisplayLines(line)).toEqual(["done", "<promise>COMPLETE</promise>"]);
   });
 
+  it("extracts text from stream_event content_block_delta", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "<promise>COMPLETE</promise>" },
+      },
+    });
+
+    expect(extractClaudeStreamDisplayLines(line)).toEqual(["<promise>COMPLETE</promise>"]);
+  });
+
+  it("ignores stream_event with non-text deltas", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+    });
+
+    expect(extractClaudeStreamDisplayLines(line)).toEqual([]);
+  });
+
   it("uses extracted Claude Code text for completion detection", () => {
     const output = [
       JSON.stringify({
@@ -109,6 +155,40 @@ describe("agent stream output extraction", () => {
 
     expect(checkTerminalPromise(output, "COMPLETE")).toBe(false);
     expect(checkTerminalPromise(extractAgentCompletionText(output, "claude-code"), "COMPLETE")).toBe(true);
+  });
+
+  it("detects promise from stream_event when assistant message is missing", () => {
+    const output = [
+      JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "<promise>COMPLETE</promise>" },
+        },
+      }),
+    ].join("\n");
+
+    expect(checkTerminalPromise(extractAgentCompletionText(output, "claude-code"), "COMPLETE")).toBe(true);
+  });
+
+  it("detects promise in raw stream-json output via containsPromiseTag fallback", () => {
+    const rawOutput = [
+      JSON.stringify({
+        type: "stream_event",
+        event: { type: "message_start", message: { id: "msg_1" } },
+      }),
+      JSON.stringify({
+        type: "text",
+        text: "<promise>COMPLETE</promise>",
+      }),
+      JSON.stringify({
+        type: "tool_summary",
+        tools: { Bash: 5 },
+      }),
+    ].join("\n");
+
+    expect(containsPromiseTag(rawOutput, "COMPLETE")).toBe(true);
   });
 
   it("extracts Cursor Agent assistant text from JSON stream lines", () => {


### PR DESCRIPTION
## Summary

- Handle `type: "stream_event"` with `content_block_delta` in `extractClaudeStreamDisplayLines`, extracting `text_delta` content from Claude Code's streaming events
- Add `containsPromiseTag()` as a full-text search fallback when the strict last-line `checkTerminalPromise()` fails, catching promise tags inside JSON values or when trailing text follows the tag
- Update `checkCompletion()` in `ralph.ts` to pass raw output for the fallback check

## Problem

When using `--agent claude-code`, ralph-wiggum invokes Claude Code with `--output-format stream-json --include-partial-messages --verbose`. Claude Code outputs NDJSON where text content appears in JSON values. The existing `checkTerminalPromise()` only checked the last non-empty line of the raw output, which would be a JSON line like `{"type":"text","text":"<promise>COMPLETE</promise>"}` rather than the plain text promise tag.

Even with the v1.3.0 fix that added `extractAgentCompletionText()` for parsing NDJSON, detection could still fail because `type: "stream_event"` messages (the actual streaming content) were not handled.

## Test plan

- [x] New tests for `containsPromiseTag()` (plain text, JSON value, case-insensitive, wrong promise)
- [x] New tests for `stream_event` extraction (text_delta, non-text deltas)
- [x] New tests for promise detection from stream_event when assistant message is missing
- [x] New tests for raw stream-json fallback detection
- [x] All existing tests continue to pass

Fixes sun-praise/ralphplus#532

🤖 Generated with [Claude Code](https://claude.com/claude-code)