### PR TITLE
fix: avoid false model configuration errors

### DIFF
--- a/ralph.ts
+++ b/ralph.ts
@@ -2273,8 +2273,12 @@ async function runRalphLoop(): Promise<void> {
         process.exit(1);
       }
 
-      // Detect model configuration errors (Issues #22, #23)
-      if (detectModelNotFoundError(combinedOutput)) {
+      // Detect model configuration errors (Issues #22, #23).
+      // Only treat these as agent configuration failures when the agent itself
+      // exits non-zero. A successful agent run may legitimately print project
+      // test output containing phrases like "model not found", and stopping the
+      // loop in that case hides the real task/test failure from the agent.
+      if (exitCode !== 0 && detectModelNotFoundError(combinedOutput)) {
         console.error("\n❌ Model configuration error detected.");
         console.error("   The agent could not find a valid model to use.");
         console.error("\n   To fix this:");


### PR DESCRIPTION
## Summary
- Only classify broad model-not-found output as an agent configuration failure when the agent process exits non-zero.
- Prevents successful agent runs from being stopped because project/test logs contain text like `model not found`.

## Context
Fixes #80.

## Validation
- `bun test ./tests/ralph.test.ts`
- `bun build ralph.ts --outfile /var/folders/1d/0byj0hb96vd30xbwb4b4b3800000gn/T/opencode/ralph-fork-check --compile`