### PR TITLE
Add qwen-code agent support for headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Open Ralph Wiggum works with multiple AI coding agents. Switch between them usin
 | **Codex** | `--agent codex` | OpenAI's Codex CLI for AI-powered development |
 | **Copilot CLI** | `--agent copilot` | GitHub Copilot CLI for agentic coding |
 | **Cursor Agent** | `--agent cursor-agent` | Cursor Agent CLI for headless AI coding |
+| **Qwen Code** | `--agent qwen-code` | Alibaba's Qwen Code CLI for headless AI coding |
 | **OpenCode** | `--agent opencode` | Default agent, open-source AI coding assistant |
 
 ```bash
@@ -61,6 +62,9 @@ ralph "Refactor the auth module" --agent copilot --max-iterations 10
 
 # Use Cursor Agent
 ralph "Add unit tests" --agent cursor-agent --max-iterations 10
+
+# Use Qwen Code
+ralph "Add unit tests" --agent qwen-code --max-iterations 10
 
 # Use OpenCode (default)
 ralph "Fix the failing tests" --max-iterations 10
@@ -91,6 +95,7 @@ Switch between AI coding agents without changing your workflow:
 - **Codex** (`--agent codex`) — OpenAI's code-specialized model
 - **Copilot CLI** (`--agent copilot`) — GitHub's agentic coding tool
 - **Cursor Agent** (`--agent cursor-agent`) — Cursor's headless AI coding agent
+- **Qwen Code** (`--agent qwen-code`) — Alibaba's Qwen Code headless CLI agent
 - **OpenCode** (`--agent opencode`) — Open-source default option
 
 ## Key Features
@@ -192,6 +197,7 @@ Configure agent binaries with these environment variables:
 | `RALPH_CODEX_BINARY` | Path to Codex CLI | `"codex"` |
 | `RALPH_COPILOT_BINARY` | Path to Copilot CLI | `"copilot"` |
 | `RALPH_CURSOR_AGENT_BINARY` | Path to Cursor Agent CLI | `"cursor-agent"` |
+| `RALPH_QWEN_CODE_BINARY` | Path to Qwen Code CLI | `"qwen-code"` |
 
 **Note for Windows users:** Ralph automatically resolves `.cmd` extensions for npm-installed CLIs. If you encounter "command not found" errors, you can use these environment variables to specify the full path to the executable.
 
@@ -203,7 +209,7 @@ Configure agent binaries with these environment variables:
 ralph "<prompt>" [options]
 
 Options:
-  --agent AGENT            AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent
+  --agent AGENT            AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent, qwen-code
   --min-iterations N       Minimum iterations before completion allowed (default: 1)
   --max-iterations N       Stop after N iterations (default: unlimited)
   --completion-promise T   Text that signals completion (default: COMPLETE)
@@ -696,6 +702,33 @@ ralph "Build a REST API" \
 - `--no-plugins` has no effect with Copilot CLI
 - Authentication: set `GH_TOKEN` / `GITHUB_TOKEN` env var, or run `copilot /login` first
 
+### Qwen Code
+
+[Qwen Code](https://github.com/QwenLM/qwen-code) is Alibaba's headless AI coding CLI agent based on the Qwen model family. It uses the same stream-JSON output format as Claude Code.
+
+**Install:**
+```bash
+npm install -g @qwen-code/qwen-code
+```
+
+**Usage:**
+```bash
+ralph "Refactor the database layer" \
+  --agent qwen-code \
+  --max-iterations 10
+
+# With a specific model
+ralph "Add integration tests for the API" \
+  --agent qwen-code \
+  --model qwen-coder-plus \
+  --max-iterations 15
+```
+
+**Notes:**
+- `--allow-all` (default) maps to `--dangerously-skip-permissions` in Qwen Code CLI
+- `--no-plugins` has no effect with Qwen Code
+- Override the binary path with `RALPH_QWEN_CODE_BINARY` env var
+
 ### Cursor Agent
 
 [Cursor Agent](https://cursor.com/cli/) is Cursor's headless CLI agent. It works with any model available through your Cursor subscription.
@@ -736,7 +769,7 @@ Each rotation entry uses the `agent:model` format:
 --rotation "agent1:model1,agent2:model2,agent3:model3"
 ```
 
-**Valid agents:** `opencode`, `claude-code`, `codex`, `copilot`, `cursor-agent`
+**Valid agents:** `opencode`, `claude-code`, `codex`, `copilot`, `cursor-agent`, `qwen-code`
 
 ### Example Usage
 
@@ -776,7 +809,7 @@ Invalid rotation entries produce clear error messages:
 
 **Invalid agent name:**
 ```
-Error: Invalid agent 'invalid' in rotation entry 'invalid:model'. Valid agents: opencode, claude-code, codex, copilot
+Error: Invalid agent 'invalid' in rotation entry 'invalid:model'. Valid agents: opencode, claude-code, codex, copilot, cursor-agent, qwen-code
 ```
 
 **Malformed entry (missing colon):**

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Configure agent binaries with these environment variables:
 | `RALPH_CODEX_BINARY` | Path to Codex CLI | `"codex"` |
 | `RALPH_COPILOT_BINARY` | Path to Copilot CLI | `"copilot"` |
 | `RALPH_CURSOR_AGENT_BINARY` | Path to Cursor Agent CLI | `"cursor-agent"` |
-| `RALPH_QWEN_CODE_BINARY` | Path to Qwen Code CLI | `"qwen-code"` |
+| `RALPH_QWEN_CODE_BINARY` | Path to Qwen Code CLI | `"qwen"` |
 
 **Note for Windows users:** Ralph automatically resolves `.cmd` extensions for npm-installed CLIs. If you encounter "command not found" errors, you can use these environment variables to specify the full path to the executable.
 
@@ -725,9 +725,11 @@ ralph "Add integration tests for the API" \
 ```
 
 **Notes:**
-- `--allow-all` (default) maps to `--dangerously-skip-permissions` in Qwen Code CLI
+- The CLI binary is `qwen`; override path with `RALPH_QWEN_CODE_BINARY` env var
+- `--allow-all` (default) maps to `--yolo` in Qwen Code CLI (auto-approves all actions)
 - `--no-plugins` has no effect with Qwen Code
-- Override the binary path with `RALPH_QWEN_CODE_BINARY` env var
+- Headless mode uses `--output-format stream-json --include-partial-messages`
+- See [headless docs](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/) for details
 
 ### Cursor Agent
 

--- a/completion.ts
+++ b/completion.ts
@@ -217,7 +217,7 @@ export function extractCursorAgentStreamDisplayLines(rawLine: string): string[] 
 }
 
 export function extractAgentCompletionText(output: string, agentType: string): string {
-  const extractStreamLines = agentType === "claude-code"
+  const extractStreamLines = agentType === "claude-code" || agentType === "qwen-code"
     ? extractClaudeStreamDisplayLines
     : agentType === "cursor-agent"
     ? extractCursorAgentStreamDisplayLines

--- a/ralph.ts
+++ b/ralph.ts
@@ -36,7 +36,7 @@ const questionsPath = join(stateDir, "ralph-questions.json");
 let customConfigPath = "";
 let initConfigPath = "";
 
-const AGENT_TYPES = ["opencode", "claude-code", "codex", "copilot", "cursor-agent"] as const;
+const AGENT_TYPES = ["opencode", "claude-code", "codex", "copilot", "cursor-agent", "qwen-code"] as const;
 type AgentType = (typeof AGENT_TYPES)[number];
 
 type AgentEnvOptions = { filterPlugins?: boolean; allowAllPermissions?: boolean };
@@ -97,6 +97,16 @@ const PARSE_PATTERNS: Record<string, (line: string) => string | null> = {
     } catch {}
     return null;
   },
+  "qwen-code": (line) => {
+    const cleanLine = stripAnsi(line);
+    const match = cleanLine.match(/(?:Using|Called|Tool:)\s+([A-Za-z0-9_.-]+)/i);
+    if (match) return match[1];
+    if (/"type"\s*:\s*"tool_use"/.test(cleanLine)) {
+      const nameMatch = cleanLine.match(/"name"\s*:\s*"([^"]+)"/);
+      if (nameMatch) return nameMatch[1];
+    }
+    return null;
+  },
   "codex": null,
   "copilot": null,
   "default": (line) => {
@@ -151,6 +161,14 @@ const ARGS_TEMPLATES: Record<string, (prompt: string, model: string, options?: A
     if (options?.allowAllPermissions) cmdArgs.push("--force");
     if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
     cmdArgs.push(prompt);
+    return cmdArgs;
+  },
+  "qwen-code": (prompt, model, options) => {
+    const cmdArgs = ["-p", prompt];
+    if (options?.streamOutput) cmdArgs.push("--output-format", "stream-json", "--include-partial-messages", "--verbose");
+    if (model) cmdArgs.push("--model", model);
+    if (options?.allowAllPermissions) cmdArgs.push("--dangerously-skip-permissions");
+    if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
     return cmdArgs;
   },
   "default": (prompt, model, options) => {
@@ -221,6 +239,7 @@ function getDefaultConfig(): RalphConfig {
       { type: "codex", command: "codex", configName: "Codex", argsTemplate: "codex", envTemplate: "default", parsePattern: "codex" },
       { type: "copilot", command: "copilot", configName: "Copilot CLI", argsTemplate: "copilot", envTemplate: "default", parsePattern: "copilot" },
       { type: "cursor-agent", command: "cursor-agent", configName: "Cursor Agent", argsTemplate: "cursor-agent", envTemplate: "default", parsePattern: "cursor-agent" },
+      { type: "qwen-code", command: "qwen-code", configName: "Qwen Code", argsTemplate: "qwen-code", envTemplate: "default", parsePattern: "qwen-code" },
     ],
   };
 }
@@ -286,6 +305,14 @@ const BUILT_IN_AGENTS: Record<AgentType, AgentConfig> = {
     parseToolOutput: PARSE_PATTERNS["cursor-agent"],
     configName: "Cursor Agent",
   },
+  "qwen-code": {
+    type: "qwen-code",
+    command: resolveCommand("qwen-code", process.env.RALPH_QWEN_CODE_BINARY),
+    buildArgs: ARGS_TEMPLATES["qwen-code"],
+    buildEnv: ENV_TEMPLATES["default"],
+    parseToolOutput: PARSE_PATTERNS["qwen-code"],
+    configName: "Qwen Code",
+  },
 };
 
 // Parse arguments early for --config and --init-config handling
@@ -337,7 +364,7 @@ Arguments:
   prompt              Task description for the AI to work on
 
 Options:
-  --agent AGENT       AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent
+  --agent AGENT       AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent, qwen-code
   --min-iterations N  Minimum iterations before completion allowed (default: 1)
   --max-iterations N  Maximum iterations before stopping (default: unlimited)
   --completion-promise TEXT  Phrase that signals completion (default: COMPLETE)
@@ -347,7 +374,7 @@ Options:
   --model MODEL       Model to use (agent-specific, e.g., anthropic/claude-sonnet)
   --rotation LIST     Agent/model rotation for each iteration (comma-separated)
                       Each entry must be "agent:model" format
-                      Valid agents: opencode, claude-code, codex, copilot, cursor-agent
+                      Valid agents: opencode, claude-code, codex, copilot, cursor-agent, qwen-code
                       Example: --rotation "opencode:claude-sonnet-4,claude-code:gpt-4o"
                       When used, --agent and --model are ignored
   --prompt-file, --file, -f  Read prompt content from a file
@@ -1645,7 +1672,7 @@ async function streamProcessOutput(
   const handleLine = (line: string, isError: boolean) => {
     lastActivityAt = Date.now();
     const tool = parseToolOutput(line);
-    const outputLines = options.agent.type === "claude-code"
+    const outputLines = options.agent.type === "claude-code" || options.agent.type === "qwen-code"
       ? extractClaudeStreamDisplayLines(line)
       : options.agent.type === "cursor-agent"
       ? extractCursorAgentStreamDisplayLines(line)
@@ -1925,6 +1952,9 @@ async function runRalphLoop(): Promise<void> {
   }
   if (disablePlugins && agentConfig.type === "cursor-agent") {
     console.warn("Warning: --no-plugins has no effect with Cursor Agent");
+  }
+  if (disablePlugins && agentConfig.type === "qwen-code") {
+    console.warn("Warning: --no-plugins has no effect with Qwen Code agent");
   }
 
   console.log(`

--- a/ralph.ts
+++ b/ralph.ts
@@ -165,9 +165,9 @@ const ARGS_TEMPLATES: Record<string, (prompt: string, model: string, options?: A
   },
   "qwen-code": (prompt, model, options) => {
     const cmdArgs = ["-p", prompt];
-    if (options?.streamOutput) cmdArgs.push("--output-format", "stream-json", "--include-partial-messages", "--verbose");
+    if (options?.streamOutput) cmdArgs.push("--output-format", "stream-json", "--include-partial-messages");
     if (model) cmdArgs.push("--model", model);
-    if (options?.allowAllPermissions) cmdArgs.push("--dangerously-skip-permissions");
+    if (options?.allowAllPermissions) cmdArgs.push("--yolo");
     if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
     return cmdArgs;
   },
@@ -239,7 +239,7 @@ function getDefaultConfig(): RalphConfig {
       { type: "codex", command: "codex", configName: "Codex", argsTemplate: "codex", envTemplate: "default", parsePattern: "codex" },
       { type: "copilot", command: "copilot", configName: "Copilot CLI", argsTemplate: "copilot", envTemplate: "default", parsePattern: "copilot" },
       { type: "cursor-agent", command: "cursor-agent", configName: "Cursor Agent", argsTemplate: "cursor-agent", envTemplate: "default", parsePattern: "cursor-agent" },
-      { type: "qwen-code", command: "qwen-code", configName: "Qwen Code", argsTemplate: "qwen-code", envTemplate: "default", parsePattern: "qwen-code" },
+      { type: "qwen-code", command: "qwen", configName: "Qwen Code", argsTemplate: "qwen-code", envTemplate: "default", parsePattern: "qwen-code" },
     ],
   };
 }
@@ -307,7 +307,7 @@ const BUILT_IN_AGENTS: Record<AgentType, AgentConfig> = {
   },
   "qwen-code": {
     type: "qwen-code",
-    command: resolveCommand("qwen-code", process.env.RALPH_QWEN_CODE_BINARY),
+    command: resolveCommand("qwen", process.env.RALPH_QWEN_CODE_BINARY),
     buildArgs: ARGS_TEMPLATES["qwen-code"],
     buildEnv: ENV_TEMPLATES["default"],
     parseToolOutput: PARSE_PATTERNS["qwen-code"],

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -206,4 +206,35 @@ describe("agent stream output extraction", () => {
     const output = "Finished\n<promise>COMPLETE</promise>";
     expect(extractAgentCompletionText(output, "opencode")).toBe(output);
   });
+
+  it("extracts Qwen Code assistant text using Claude stream format", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "done\n<promise>COMPLETE</promise>" }],
+      },
+    });
+
+    expect(extractClaudeStreamDisplayLines(line)).toEqual(["done", "<promise>COMPLETE</promise>"]);
+  });
+
+  it("uses extracted Qwen Code text for completion detection", () => {
+    const output = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Implemented changes." }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "<promise>COMPLETE</promise>" }],
+        },
+      }),
+    ].join("\n");
+
+    expect(checkTerminalPromise(output, "COMPLETE")).toBe(false);
+    expect(checkTerminalPromise(extractAgentCompletionText(output, "qwen-code"), "COMPLETE")).toBe(true);
+  });
 });


### PR DESCRIPTION
Registers Qwen Code (Alibaba's coding CLI) as a first-class agent type alongside claude-code, codex, copilot, cursor-agent, and opencode.

- Adds "qwen-code" to AGENT_TYPES, PARSE_PATTERNS, ARGS_TEMPLATES, BUILT_IN_AGENTS, and getDefaultConfig()
- Reuses claude-code stream-JSON args (-p, --output-format stream-json, --dangerously-skip-permissions) since Qwen Code uses the same interface
- Routes qwen-code stream lines through extractClaudeStreamDisplayLines in both streamProcessOutput and extractAgentCompletionText
- Exposes RALPH_QWEN_CODE_BINARY env var for binary path override
- Updates help text, README, and adds qwen-code completion-detection tests