### PR TITLE
Keep OMX goal mode on supported permission flags

### DIFF
--- a/ralph.ts
+++ b/ralph.ts
@@ -1882,7 +1882,10 @@ function buildCodexGoalInvocation(params: {
   const args = ["exec"];
   if (params.model) args.push("--model", params.model);
   if (params.allowAllPermissions) {
-    args.push("--sandbox", "danger-full-access", "--dangerously-bypass-approvals-and-sandbox");
+    args.push("--sandbox", "danger-full-access");
+    if (params.backend !== "omx") {
+      args.push("--dangerously-bypass-approvals-and-sandbox");
+    }
   }
   if (params.backend === "omx") {
     const reasoning = process.env.OMX_RALPH_REASONING || "high";

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -348,7 +348,6 @@ echo '<promise>COMPLETE</promise>'
           "--no-commit",
           "--no-questions",
           "--no-stream",
-          "--no-allow-all",
         ],
         cwd: workdir,
         env: {
@@ -369,7 +368,10 @@ echo '<promise>COMPLETE</promise>'
 
       expect(exitCode).toBe(0);
       expect(`${stdout}\n${stderr}`).toContain("[ralph] Native Codex /goal: attempting through OMX");
-      expect(readFileSync(capturedArgs, "utf-8").split("\n")[0]).toBe("exec");
+      const argsText = readFileSync(capturedArgs, "utf-8");
+      expect(argsText.split("\n")[0]).toBe("exec");
+      expect(argsText).toContain("--sandbox\ndanger-full-access");
+      expect(argsText).not.toContain("--dangerously-bypass-approvals-and-sandbox");
       expect(readFileSync(capturedPrompt, "utf-8").startsWith("/goal ")).toBe(true);
       expect(readFileSync(join(workdir, ".ralph", "codex-goal-ledger.jsonl"), "utf-8")).toContain('"promptStartsWithGoal":true');
     } finally {


### PR DESCRIPTION
Thanks again for maintaining Open Ralph Wiggum — it has been genuinely useful to me. I really appreciate having such a small, practical Ralph loop framework to build on.

This follow-up addresses the last Bugbot note from #85. Even though my local OMX currently accepts the Codex bypass flag, the OMX adapter path already strips it, so this keeps the native OMX goal-mode path consistent: OMX gets `--sandbox danger-full-access`, while the Codex-only `--dangerously-bypass-approvals-and-sandbox` flag remains limited to the bare Codex backend.

I also adjusted the OMX goal-mode regression test to cover the default allow-all path instead of masking it with `--no-allow-all`.

Verified:
- `bun test ./tests/ralph.test.ts -t "sends /goal"`
- `bun test ./tests/ralph.test.ts`
- `bun build ralph.ts --outfile /tmp/ralph-test-bin --compile`
- `git diff --check`

On a more speculative note: I’m thinking about exploring a “ralphflow” idea later — combining Ralph with workflow-style orchestration. It sounds a bit crazy, but in day-to-day work we are often just running loops: attempt, inspect, adjust, verify, repeat. In that sense: Ralph is all you need!!! 😄
