### PR TITLE
Add native Pi support and live iteration steering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
         run: bun test
 
       - name: Type check
-        run: bun build ralph.ts --outfile /dev/null
+        run: bun build ralph.ts --target=bun --outfile /dev/null

--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ ralph "Refactor the auth module" \
 ```
 
 **Notes:**
-- Ralph runs each Pi iteration with `pi -p --no-session`
+- Ralph runs each Pi iteration with `pi -p --no-session`; streaming mode adds `--mode json` for assistant output and tool summaries
 - The CLI binary is `pi`; override it with `RALPH_PI_BINARY`
 - Pi model patterns are passed through with `--model`
 - Pass Pi-specific flags after `--`, for example `-- --approve` to trust project-local resources

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Switch between AI coding agents without changing your workflow:
 - **Autonomous Execution** — Set it running and come back to finished code
 - **Task Tracking** — Built-in task management with `--tasks` mode
 - **Live Monitoring** — Check progress with `--status` from another terminal
-- **Mid-Loop Hints** — Inject guidance with `--add-context` without stopping
+- **Mid-Loop Guidance** — Use `--add-context` for the next iteration or steer the active Pi turn with `--steer`
 
 ## Why Use an Agentic Loop?
 
@@ -400,6 +400,9 @@ ralph --status
 # Add context/hints for the next iteration
 ralph --add-context "Focus on fixing the auth module first"
 
+# Steer the current Pi iteration at its next safe turn boundary
+ralph --steer "Inspect the failing test before continuing"
+
 # Clear pending context
 ralph --clear-context
 ```
@@ -448,6 +451,20 @@ ralph --add-context "Try using the singleton pattern for config"
 ```
 
 Context is automatically consumed after one iteration.
+
+### Steering the Current Pi Iteration
+
+When the active iteration uses Pi, steer that same run from another terminal in the same project directory:
+
+```bash
+ralph --steer "Stop the broad refactor and inspect the failing parser test"
+```
+
+Pi consumes the message after the current assistant turn finishes its tool calls and before the next model call. The command waits until that safe turn boundary is reached. It does not interrupt a running tool.
+
+`--steer` fails without changing context when the active agent is not Pi, the iteration has ended, no loop is active, or multiple loops are active in the same workspace. It never falls back to `--add-context`. Closing the controller before it reports success does not retract a message Pi has already accepted.
+
+Use `--add-context` when guidance should apply to the next iteration. Ralph's control layer does not write steering text to state, history, or context files. Pi extensions and model providers may have their own external logging. Pi steering requires a Pi release with RPC mode and `agent_settled` support.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">Open Ralph Wiggum</h1>
-  <h3 align="center">Autonomous Agentic Loop for Claude Code, Codex, Copilot CLI, Cursor Agent, Qwen Code & OpenCode</h3>
+  <h3 align="center">Autonomous Agentic Loop for Claude Code, Codex, Copilot CLI, Cursor Agent, Qwen Code, Pi & OpenCode</h3>
 </p>
 
 <p align="center">
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <em>Works with <b>Claude Code</b>, <b>OpenAI Codex</b>, <b>Copilot CLI</b>, <b>Cursor Agent</b>, <b>Qwen Code</b>, and <b>OpenCode</b> — switch agents with <code>--agent</code>.</em><br>
+  <em>Works with <b>Claude Code</b>, <b>OpenAI Codex</b>, <b>Copilot CLI</b>, <b>Cursor Agent</b>, <b>Qwen Code</b>, <b>Pi</b>, and <b>OpenCode</b> — switch agents with <code>--agent</code>.</em><br>
   <em>Based on the <a href="https://ghuntley.com/ralph/">Ralph Wiggum technique</a> by Geoffrey Huntley</em>
 </p>
 
@@ -48,6 +48,7 @@ Open Ralph Wiggum works with multiple AI coding agents. Switch between them usin
 | **Copilot CLI** | `--agent copilot` | GitHub Copilot CLI for agentic coding |
 | **Cursor Agent** | `--agent cursor-agent` | Cursor Agent CLI for headless AI coding |
 | **Qwen Code** | `--agent qwen-code` | Alibaba's Qwen Code CLI for headless AI coding |
+| **Pi** | `--agent pi` | Minimal, extensible terminal coding agent |
 | **OpenCode** | `--agent opencode` | Default agent, open-source AI coding assistant |
 
 ```bash
@@ -66,6 +67,9 @@ ralph "Add unit tests" --agent cursor-agent --max-iterations 10
 # Use Qwen Code
 ralph "Add unit tests" --agent qwen-code --max-iterations 10
 
+# Use Pi
+ralph "Add unit tests" --agent pi --max-iterations 10
+
 # Use OpenCode (default)
 ralph "Fix the failing tests" --max-iterations 10
 ```
@@ -74,14 +78,14 @@ ralph "Fix the failing tests" --max-iterations 10
 
 ## What is Open Ralph Wiggum?
 
-Open Ralph Wiggum implements the **Ralph Wiggum technique** — an autonomous agentic loop where an AI coding agent (Claude Code, Codex, Copilot CLI, Cursor Agent, Qwen Code, or OpenCode) receives the **same prompt repeatedly** until it completes a task. Each iteration, the AI sees its previous work in files and git history, enabling self-correction and incremental progress.
+Open Ralph Wiggum implements the **Ralph Wiggum technique** — an autonomous agentic loop where an AI coding agent (Claude Code, Codex, Copilot CLI, Cursor Agent, Qwen Code, Pi, or OpenCode) receives the **same prompt repeatedly** until it completes a task. Each iteration, the AI sees its previous work in files and git history, enabling self-correction and incremental progress.
 
 This is a **CLI tool** that wraps any supported AI coding agent in a persistent development loop. No plugins required — just install and run.
 
 ```bash
 # The essence of the Ralph loop:
 while true; do
-  claude-code "Build feature X. Output <promise>DONE</promise> when complete."  # or codex, copilot, cursor-agent, qwen, opencode
+  claude-code "Build feature X. Output <promise>DONE</promise> when complete."  # or codex, copilot, cursor-agent, qwen, pi, opencode
 done
 ```
 
@@ -96,11 +100,12 @@ Switch between AI coding agents without changing your workflow:
 - **Copilot CLI** (`--agent copilot`) — GitHub's agentic coding tool
 - **Cursor Agent** (`--agent cursor-agent`) — Cursor's headless AI coding agent
 - **Qwen Code** (`--agent qwen-code`) — Alibaba's Qwen Code headless CLI agent
+- **Pi** (`--agent pi`) — Minimal, extensible terminal coding agent
 - **OpenCode** (`--agent opencode`) — Open-source default option
 
 ## Key Features
 
-- **Multi-Agent Support** — Use Claude Code, Codex, Copilot CLI, Cursor Agent, Qwen Code, or OpenCode with the same workflow
+- **Multi-Agent Support** — Use Claude Code, Codex, Copilot CLI, Cursor Agent, Qwen Code, Pi, or OpenCode with the same workflow
 - **Self-Correcting Loops** — Agent sees its previous work and fixes its own mistakes
 - **Autonomous Execution** — Set it running and come back to finished code
 - **Task Tracking** — Built-in task management with `--tasks` mode
@@ -128,6 +133,7 @@ Switch between AI coding agents without changing your workflow:
   - [Copilot CLI](https://github.com/github/copilot-cli) — GitHub's Copilot CLI
   - [Cursor Agent](https://cursor.com/cli/) — Cursor's headless Agent CLI
   - [Qwen Code](https://github.com/QwenLM/qwen-code) — Alibaba's Qwen Code CLI
+  - [Pi](https://pi.dev) — Minimal, extensible terminal coding agent
   - [OpenCode](https://opencode.ai) — Open-source AI coding assistant
 
 ### npm (recommended)
@@ -191,6 +197,10 @@ ralph "Create a small CLI and document usage. Output <promise>COMPLETE</promise>
 ralph "Create a small CLI and document usage. Output <promise>COMPLETE</promise> when done." \
   --agent qwen-code --max-iterations 5
 
+# Use Pi
+ralph "Create a small CLI and document usage. Output <promise>COMPLETE</promise> when done." \
+  --agent pi --max-iterations 5
+
 # Complex project with Tasks Mode
 ralph "Build a full-stack web application with user auth and database" \
   --tasks --max-iterations 50
@@ -213,6 +223,7 @@ Configure agent binaries with these environment variables:
 | `RALPH_COPILOT_BINARY` | Path to Copilot CLI | `"copilot"` |
 | `RALPH_CURSOR_AGENT_BINARY` | Path to Cursor Agent CLI | `"cursor-agent"` |
 | `RALPH_QWEN_CODE_BINARY` | Path to Qwen Code CLI | `"qwen"` |
+| `RALPH_PI_BINARY` | Path to Pi CLI | `"pi"` |
 
 **Note for Windows users:** Ralph automatically resolves `.cmd` extensions for npm-installed CLIs. If you encounter "command not found" errors, you can use these environment variables to specify the full path to the executable.
 
@@ -224,7 +235,7 @@ Configure agent binaries with these environment variables:
 ralph "<prompt>" [options]
 
 Options:
-  --agent AGENT            AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent, qwen-code
+  --agent AGENT            AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent, qwen-code, pi
   --codex-goal             Run Codex iterations in goal mode; final Codex/OMX prompt starts with /goal
   --codex-backend BACKEND  Backend for --codex-goal: codex or omx (default: detect)
   --codex-goal-native      Force a native /goal attempt even when backend support is unconfirmed
@@ -786,6 +797,36 @@ ralph "Add integration tests for the API" \
 - Headless mode uses `--output-format stream-json --include-partial-messages`
 - See [headless docs](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/) for details
 
+### Pi
+
+[Pi](https://pi.dev) is a minimal, extensible terminal coding agent.
+
+**Install:**
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+**Usage:**
+```bash
+ralph "Fix the failing tests" \
+  --agent pi \
+  --max-iterations 10
+
+# With a specific model
+ralph "Refactor the auth module" \
+  --agent pi \
+  --model anthropic/claude-sonnet-4-5 \
+  --max-iterations 15
+```
+
+**Notes:**
+- Ralph runs each Pi iteration with `pi -p --no-session`
+- The CLI binary is `pi`; override it with `RALPH_PI_BINARY`
+- Pi model patterns are passed through with `--model`
+- Pass Pi-specific flags after `--`, for example `-- --approve` to trust project-local resources
+- Pi has no built-in permission prompts, so Ralph's `--allow-all` and `--no-allow-all` add no Pi flags
+- `--no-plugins` has no effect with Pi
+
 ### Cursor Agent
 
 [Cursor Agent](https://cursor.com/cli/) is Cursor's headless CLI agent. It works with any model available through your Cursor subscription.
@@ -826,7 +867,7 @@ Each rotation entry uses the `agent:model` format:
 --rotation "agent1:model1,agent2:model2,agent3:model3"
 ```
 
-**Valid agents:** `opencode`, `claude-code`, `codex`, `copilot`, `cursor-agent`, `qwen-code`
+**Valid agents:** `opencode`, `claude-code`, `codex`, `copilot`, `cursor-agent`, `qwen-code`, `pi`
 
 ### Example Usage
 
@@ -866,7 +907,7 @@ Invalid rotation entries produce clear error messages:
 
 **Invalid agent name:**
 ```
-Error: Invalid agent 'invalid' in rotation entry 'invalid:model'. Valid agents: opencode, claude-code, codex, copilot, cursor-agent, qwen-code
+Error: Invalid agent 'invalid' in rotation entry 'invalid:model'. Valid agents: opencode, claude-code, codex, copilot, cursor-agent, qwen-code, pi
 ```
 
 **Malformed entry (missing colon):**

--- a/agent-iteration.ts
+++ b/agent-iteration.ts
@@ -1,0 +1,612 @@
+import {
+  createPiStreamReducer,
+  extractAgentCompletionText,
+  extractClaudeStreamDisplayLines,
+  extractCursorAgentStreamDisplayLines,
+} from "./completion";
+
+const MAX_PI_RPC_RECORD_BYTES = 16 * 1024 * 1024;
+const HEARTBEAT_INTERVAL_MS = process.env.NODE_ENV === "test" ? 1000 : 10000;
+const TOOL_SUMMARY_INTERVAL_MS = 3000;
+
+export interface AgentIterationAgent {
+  type: string;
+  command: string;
+  parseToolOutput: (line: string) => string | null;
+}
+
+export interface AgentIterationInput {
+  agent: AgentIterationAgent;
+  args: string[];
+  cwd: string;
+  env: Record<string, string | undefined>;
+  prompt: string;
+  streamOutput: boolean;
+  compactTools: boolean;
+  iterationStart: number;
+  lastActivityTimeoutMs: number;
+  signal?: AbortSignal;
+}
+
+export interface IterationResult {
+  completionText: string;
+  evidenceText: string;
+  rawPromiseText?: string;
+  question: string | null;
+  toolCounts: Map<string, number>;
+  exitCode: number;
+  termination: "agent-settled" | "process-exit";
+}
+
+export interface AgentIteration {
+  readonly settled: Promise<IterationResult>;
+  readonly steer?: (text: string) => Promise<void>;
+}
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function formatToolSummary(toolCounts: Map<string, number>, maxItems = 6): string {
+  const entries = Array.from(toolCounts.entries()).sort((a, b) => b[1] - a[1]);
+  const shown = entries.slice(0, maxItems).map(([name, count]) => `${name} ${count}`);
+  const remaining = entries.length - shown.length;
+  if (remaining > 0) shown.push(`+${remaining} more`);
+  return shown.join(" • ");
+}
+
+function terminateProcess(proc: ReturnType<typeof Bun.spawn>): void {
+  try {
+    proc.kill("SIGTERM");
+  } catch {}
+}
+
+function startPiIteration(input: AgentIterationInput): AgentIteration {
+  const proc = Bun.spawn([input.agent.command, ...input.args], {
+    cwd: input.cwd,
+    env: input.env,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (!proc.stdin || typeof proc.stdin === "number") {
+    terminateProcess(proc);
+    throw new Error("Pi RPC stdin is unavailable");
+  }
+
+  const stdin = proc.stdin;
+  const reducer = createPiStreamReducer();
+  const toolCounts = new Map<string, number>();
+  const pendingCommands = new Map<string, Deferred<Record<string, unknown>>>();
+  const agentStarted = deferred<void>();
+  const agentSettled = deferred<void>();
+  const operationEnded = deferred<void>();
+  const protocolFailed = deferred<Error>();
+  let commandSequence = 0;
+  let ended = false;
+  let fatalError: Error | null = null;
+  let currentSteeringCount = 0;
+  let pendingDelivery: { queuedCount: number; completion: Deferred<void> } | null = null;
+  let steerTail: Promise<void> = Promise.resolve();
+  let lastActivityAt = Date.now();
+  let lastPrintedAt = Date.now();
+  let lastToolSummaryAt = 0;
+  let activityTimedOut = false;
+  let receivedAgentSettled = false;
+  let stdoutReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let stderrReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+  const failProtocol = (error: unknown) => {
+    if (fatalError) return;
+    fatalError = error instanceof Error ? error : new Error(String(error));
+    protocolFailed.resolve(fatalError);
+    terminateProcess(proc);
+  };
+
+  const rejectPending = (error: Error) => {
+    for (const pending of pendingCommands.values()) pending.reject(error);
+    pendingCommands.clear();
+    if (pendingDelivery) {
+      pendingDelivery.completion.reject(error);
+      pendingDelivery = null;
+    }
+  };
+
+  const writeMessage = (message: Record<string, unknown>) => {
+    if (ended) throw new Error("Pi iteration has ended");
+    stdin.write(`${JSON.stringify(message)}\n`);
+    stdin.flush();
+  };
+
+  const sendCommand = (command: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    const id = `ralph-${++commandSequence}`;
+    const completion = deferred<Record<string, unknown>>();
+    pendingCommands.set(id, completion);
+    try {
+      writeMessage({ id, ...command });
+    } catch (error) {
+      pendingCommands.delete(id);
+      completion.reject(error);
+    }
+    return completion.promise;
+  };
+
+  const maybePrintToolSummary = (force = false) => {
+    if (!input.streamOutput || !input.compactTools || toolCounts.size === 0) return;
+    const now = Date.now();
+    if (!force && now - lastToolSummaryAt < TOOL_SUMMARY_INTERVAL_MS) return;
+    console.log(`| Tools    ${formatToolSummary(toolCounts)}`);
+    lastPrintedAt = now;
+    lastToolSummaryAt = now;
+  };
+
+  const handleProtocolLine = (rawLine: string) => {
+    lastActivityAt = Date.now();
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (!line) return;
+    if (Buffer.byteLength(line) > MAX_PI_RPC_RECORD_BYTES) {
+      failProtocol(new Error("Pi RPC record exceeds the 16 MiB limit"));
+      return;
+    }
+
+    let message: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(line);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("RPC record must be a JSON object");
+      }
+      message = parsed as Record<string, unknown>;
+    } catch (error) {
+      failProtocol(new Error(`Invalid Pi RPC record: ${error instanceof Error ? error.message : String(error)}`));
+      return;
+    }
+
+    if (message.type === "response") {
+      const id = typeof message.id === "string" ? message.id : "";
+      const pending = pendingCommands.get(id);
+      if (!pending) return;
+      pendingCommands.delete(id);
+      if (message.success === true) {
+        pending.resolve(message);
+      } else {
+        const rpcError = message.error && typeof message.error === "object"
+          ? (message.error as Record<string, unknown>).message
+          : message.error;
+        pending.reject(new Error(typeof rpcError === "string" ? rpcError : "Pi RPC command failed"));
+      }
+      return;
+    }
+
+    if (message.type === "extension_ui_request") {
+      const method = typeof message.method === "string" ? message.method : "";
+      if (["select", "confirm", "input", "editor"].includes(method) && typeof message.id === "string") {
+        writeMessage({ type: "extension_ui_response", id: message.id, cancelled: true });
+      }
+      return;
+    }
+
+    if (message.type === "agent_start") agentStarted.resolve();
+    if (message.type === "agent_settled") {
+      receivedAgentSettled = true;
+      agentSettled.resolve();
+    }
+
+    if (message.type === "queue_update" && Array.isArray(message.steering)) {
+      const nextCount = message.steering.length;
+      if (pendingDelivery) {
+        if (nextCount > currentSteeringCount) {
+          pendingDelivery.queuedCount = nextCount;
+        } else if (pendingDelivery.queuedCount > 0 && nextCount < pendingDelivery.queuedCount) {
+          pendingDelivery.completion.resolve();
+          pendingDelivery = null;
+        }
+      }
+      currentSteeringCount = nextCount;
+    }
+
+    const effect = reducer.pushLine(line, false);
+    if (effect.toolName) {
+      toolCounts.set(effect.toolName, (toolCounts.get(effect.toolName) ?? 0) + 1);
+      if (input.compactTools && effect.displayLines.length === 0) maybePrintToolSummary();
+    }
+    if (input.streamOutput) {
+      for (const outputLine of effect.displayLines) {
+        console.log(outputLine);
+        lastPrintedAt = Date.now();
+      }
+    }
+  };
+
+  const readStdout = async () => {
+    if (!proc.stdout) return;
+    const reader = proc.stdout.getReader();
+    stdoutReader = reader;
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let newline = buffer.indexOf("\n");
+        while (newline !== -1) {
+          handleProtocolLine(buffer.slice(0, newline));
+          buffer = buffer.slice(newline + 1);
+          newline = buffer.indexOf("\n");
+        }
+        if (Buffer.byteLength(buffer) > MAX_PI_RPC_RECORD_BYTES) {
+          failProtocol(new Error("Pi RPC record exceeds the 16 MiB limit"));
+          return;
+        }
+      }
+      buffer += decoder.decode();
+      if (buffer.length > 0) {
+        failProtocol(new Error("Pi RPC stdout ended with an incomplete JSONL record"));
+      }
+    } finally {
+      stdoutReader = null;
+      reader.releaseLock();
+    }
+  };
+
+  const readStderr = async () => {
+    if (!proc.stderr) return;
+    const reader = proc.stderr.getReader();
+    stderrReader = reader;
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        lastActivityAt = Date.now();
+        buffer += chunk;
+        let newline = buffer.indexOf("\n");
+        while (newline !== -1) {
+          const line = buffer.slice(0, newline).replace(/\r$/, "");
+          reducer.pushLine(line, true);
+          if (input.streamOutput && line) console.error(line);
+          buffer = buffer.slice(newline + 1);
+          newline = buffer.indexOf("\n");
+        }
+      }
+      buffer += decoder.decode();
+      if (buffer) {
+        reducer.pushLine(buffer, true);
+        if (input.streamOutput) console.error(buffer);
+      }
+    } finally {
+      stderrReader = null;
+      reader.releaseLock();
+    }
+  };
+
+  const stdoutDone = readStdout().catch(failProtocol);
+  const stderrDone = readStderr().catch(failProtocol);
+
+  const heartbeatTimer = setInterval(() => {
+    const now = Date.now();
+    if (input.streamOutput && now - lastPrintedAt >= HEARTBEAT_INTERVAL_MS) {
+      console.log(
+        `⏳ working... elapsed ${formatDuration(now - input.iterationStart)} · last activity ${formatDuration(now - lastActivityAt)} ago`,
+      );
+      lastPrintedAt = now;
+    }
+    if (
+      !activityTimedOut &&
+      input.lastActivityTimeoutMs > 0 &&
+      now - lastActivityAt >= input.lastActivityTimeoutMs
+    ) {
+      activityTimedOut = true;
+      console.log(
+        `\n⏰ Inactivity timeout: no activity for ${formatDuration(input.lastActivityTimeoutMs)}. Restarting iteration...`,
+      );
+      terminateProcess(proc);
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+
+  const abortHandler = () => terminateProcess(proc);
+  input.signal?.addEventListener("abort", abortHandler, { once: true });
+  if (input.signal?.aborted) terminateProcess(proc);
+
+  const promptAccepted = sendCommand({ type: "prompt", message: input.prompt });
+  const processExited = proc.exited.then(exitCode => ({ kind: "exit" as const, exitCode }));
+  const settledEvent = agentSettled.promise.then(() => ({ kind: "settled" as const }));
+  const protocolError = protocolFailed.promise.then(error => ({ kind: "protocol" as const, error }));
+
+  const settled = (async (): Promise<IterationResult> => {
+    let exitCode: number;
+    try {
+      const promptOrExit = await Promise.race([
+        promptAccepted.then(() => ({ kind: "prompt" as const })),
+        processExited,
+        protocolError,
+      ]);
+      if (promptOrExit.kind === "protocol") throw promptOrExit.error;
+
+      if (promptOrExit.kind === "exit") {
+        exitCode = promptOrExit.exitCode;
+      } else {
+        const outcome = await Promise.race([settledEvent, processExited, protocolError]);
+        if (outcome.kind === "protocol") throw outcome.error;
+        if (outcome.kind === "settled") {
+          ended = true;
+          operationEnded.resolve();
+          stdin.end();
+          exitCode = await proc.exited;
+        } else {
+          exitCode = outcome.exitCode;
+        }
+      }
+
+      ended = true;
+      operationEnded.resolve();
+      rejectPending(new Error("Pi iteration ended before the request was delivered"));
+      await Promise.all([stdoutDone, stderrDone]);
+      if (fatalError) throw fatalError;
+
+      if (input.compactTools) maybePrintToolSummary(true);
+      const summary = reducer.finish();
+      if (!input.streamOutput) {
+        if (summary.diagnosticText) console.error(summary.diagnosticText);
+        if (summary.completionText) console.log(summary.completionText);
+      }
+      return {
+        completionText: summary.completionText,
+        evidenceText: `${summary.completionText}\n${summary.diagnosticText}`,
+        question: summary.question,
+        toolCounts,
+        exitCode,
+        termination: receivedAgentSettled ? "agent-settled" : "process-exit",
+      };
+    } catch (error) {
+      terminateProcess(proc);
+      await Promise.allSettled([
+        (stdoutReader as ReadableStreamDefaultReader<Uint8Array> | null)?.cancel(),
+        (stderrReader as ReadableStreamDefaultReader<Uint8Array> | null)?.cancel(),
+      ]);
+      throw error;
+    } finally {
+      ended = true;
+      operationEnded.resolve();
+      rejectPending(fatalError ?? new Error("Pi iteration ended before the request was delivered"));
+      clearInterval(heartbeatTimer);
+      input.signal?.removeEventListener("abort", abortHandler);
+      try {
+        stdin.end();
+      } catch {}
+      await Promise.allSettled([proc.exited, stdoutDone, stderrDone]);
+    }
+  })();
+
+  const steer = (text: string): Promise<void> => {
+    const run = async () => {
+      if (!text.trim()) throw new Error("Steering text must not be empty");
+      const active = await Promise.race([
+        Promise.all([promptAccepted, agentStarted.promise]).then(() => true),
+        operationEnded.promise.then(() => false),
+      ]);
+      if (!active || ended) throw new Error("Pi iteration is no longer running");
+
+      const delivery = deferred<void>();
+      pendingDelivery = { queuedCount: 0, completion: delivery };
+      try {
+        await Promise.all([
+          sendCommand({ type: "steer", message: text }),
+          delivery.promise,
+        ]);
+      } finally {
+        if (pendingDelivery?.completion === delivery) pendingDelivery = null;
+      }
+    };
+
+    const next = steerTail.then(run, run);
+    steerTail = next.catch(() => {});
+    return next;
+  };
+
+  return { settled, steer };
+}
+
+async function streamSpawnProcess(
+  proc: ReturnType<typeof Bun.spawn>,
+  input: AgentIterationInput,
+): Promise<{ stdoutText: string; stderrText: string; toolCounts: Map<string, number> }> {
+  const toolCounts = new Map<string, number>();
+  let stdoutText = "";
+  let stderrText = "";
+  let lastPrintedAt = Date.now();
+  let lastActivityAt = Date.now();
+  let lastToolSummaryAt = 0;
+  let activityTimedOut = false;
+
+  const maybePrintToolSummary = (force = false) => {
+    if (!input.compactTools || toolCounts.size === 0) return;
+    const now = Date.now();
+    if (!force && now - lastToolSummaryAt < TOOL_SUMMARY_INTERVAL_MS) return;
+    console.log(`| Tools    ${formatToolSummary(toolCounts)}`);
+    lastPrintedAt = now;
+    lastToolSummaryAt = now;
+  };
+
+  const handleLine = (line: string, isError: boolean) => {
+    lastActivityAt = Date.now();
+    const tool = input.agent.parseToolOutput(line);
+    const outputLines = input.agent.type === "claude-code" || input.agent.type === "qwen-code"
+      ? extractClaudeStreamDisplayLines(line)
+      : input.agent.type === "cursor-agent"
+      ? extractCursorAgentStreamDisplayLines(line)
+      : [line];
+
+    if (tool) {
+      toolCounts.set(tool, (toolCounts.get(tool) ?? 0) + 1);
+      if (input.compactTools && outputLines.length === 0) {
+        maybePrintToolSummary();
+        return;
+      }
+    }
+
+    for (const outputLine of outputLines) {
+      if (isError) console.error(outputLine);
+      else console.log(outputLine);
+      lastPrintedAt = Date.now();
+    }
+  };
+
+  const streamText = async (
+    stream: ReadableStream<Uint8Array> | null,
+    onText: (chunk: string) => void,
+    isError: boolean,
+  ) => {
+    if (!stream) return;
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        const text = decoder.decode(value, { stream: true });
+        if (!text) continue;
+        onText(text);
+        buffer += text;
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? "";
+        for (const line of lines) handleLine(line, isError);
+      }
+      const flushed = decoder.decode();
+      if (flushed) {
+        onText(flushed);
+        buffer += flushed;
+      }
+      if (buffer) handleLine(buffer, isError);
+    } finally {
+      reader.releaseLock();
+    }
+  };
+
+  const heartbeatTimer = setInterval(() => {
+    const now = Date.now();
+    if (now - lastPrintedAt >= HEARTBEAT_INTERVAL_MS) {
+      console.log(
+        `⏳ working... elapsed ${formatDuration(now - input.iterationStart)} · last activity ${formatDuration(now - lastActivityAt)} ago`,
+      );
+      lastPrintedAt = now;
+    }
+    if (
+      !activityTimedOut &&
+      input.lastActivityTimeoutMs > 0 &&
+      now - lastActivityAt >= input.lastActivityTimeoutMs
+    ) {
+      activityTimedOut = true;
+      console.log(
+        `\n⏰ Inactivity timeout: no activity for ${formatDuration(input.lastActivityTimeoutMs)}. Restarting iteration...`,
+      );
+      terminateProcess(proc);
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+
+  try {
+    await Promise.all([
+      streamText(proc.stdout as ReadableStream<Uint8Array> | null, chunk => { stdoutText += chunk; }, false),
+      streamText(proc.stderr as ReadableStream<Uint8Array> | null, chunk => { stderrText += chunk; }, true),
+    ]);
+  } finally {
+    clearInterval(heartbeatTimer);
+  }
+
+  if (input.compactTools) maybePrintToolSummary(true);
+  return { stdoutText, stderrText, toolCounts };
+}
+
+function collectToolSummaryFromText(
+  text: string,
+  agent: AgentIterationAgent,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const line of text.split(/\r?\n/)) {
+    const tool = agent.parseToolOutput(line);
+    if (tool) counts.set(tool, (counts.get(tool) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function startSpawnIteration(input: AgentIterationInput): AgentIteration {
+  const proc = Bun.spawn([input.agent.command, ...input.args], {
+    cwd: input.cwd,
+    env: input.env,
+    stdin: "inherit",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const abortHandler = () => terminateProcess(proc);
+  input.signal?.addEventListener("abort", abortHandler, { once: true });
+  if (input.signal?.aborted) terminateProcess(proc);
+
+  const settled = (async (): Promise<IterationResult> => {
+    try {
+      let stdoutText: string;
+      let stderrText: string;
+      let toolCounts: Map<string, number>;
+
+      if (input.streamOutput) {
+        const streamed = await streamSpawnProcess(proc, input);
+        stdoutText = streamed.stdoutText;
+        stderrText = streamed.stderrText;
+        toolCounts = streamed.toolCounts;
+      } else {
+        [stdoutText, stderrText] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        toolCounts = collectToolSummaryFromText(`${stdoutText}\n${stderrText}`, input.agent);
+      }
+
+      const exitCode = await proc.exited;
+      if (!input.streamOutput) {
+        if (stderrText) console.error(stderrText);
+        if (stdoutText) console.log(stdoutText);
+      }
+
+      return {
+        completionText: extractAgentCompletionText(stdoutText, input.agent.type),
+        evidenceText: `${stdoutText}\n${stderrText}`,
+        rawPromiseText: stdoutText,
+        question: null,
+        toolCounts,
+        exitCode,
+        termination: "process-exit",
+      };
+    } finally {
+      input.signal?.removeEventListener("abort", abortHandler);
+    }
+  })();
+
+  return { settled };
+}
+
+export function startAgentIteration(input: AgentIterationInput): AgentIteration {
+  return input.agent.type === "pi" ? startPiIteration(input) : startSpawnIteration(input);
+}

--- a/agent-iteration.ts
+++ b/agent-iteration.ts
@@ -331,15 +331,23 @@ function startPiIteration(input: AgentIterationInput): AgentIteration {
   if (input.signal?.aborted) terminateProcess(proc);
 
   const promptAccepted = sendCommand({ type: "prompt", message: input.prompt });
+  const promptOutcome = promptAccepted.then(
+    () => ({ kind: "prompt" as const }),
+    error => ({
+      kind: "prompt-error" as const,
+      error: error instanceof Error ? error : new Error(String(error)),
+    }),
+  );
   const processExited = proc.exited.then(exitCode => ({ kind: "exit" as const, exitCode }));
   const settledEvent = agentSettled.promise.then(() => ({ kind: "settled" as const }));
   const protocolError = protocolFailed.promise.then(error => ({ kind: "protocol" as const, error }));
 
   const settled = (async (): Promise<IterationResult> => {
     let exitCode: number;
+    let promptError: Error | undefined;
     try {
       const promptOrExit = await Promise.race([
-        promptAccepted.then(() => ({ kind: "prompt" as const })),
+        promptOutcome,
         processExited,
         protocolError,
       ]);
@@ -347,6 +355,11 @@ function startPiIteration(input: AgentIterationInput): AgentIteration {
 
       if (promptOrExit.kind === "exit") {
         exitCode = promptOrExit.exitCode;
+      } else if (promptOrExit.kind === "prompt-error") {
+        promptError = promptOrExit.error;
+        terminateProcess(proc);
+        exitCode = await proc.exited;
+        if (exitCode === 0) exitCode = 1;
       } else {
         const outcome = await Promise.race([settledEvent, processExited, protocolError]);
         if (outcome.kind === "protocol") throw outcome.error;
@@ -368,13 +381,17 @@ function startPiIteration(input: AgentIterationInput): AgentIteration {
 
       if (input.compactTools) maybePrintToolSummary(true);
       const summary = reducer.finish();
+      const promptDiagnostic = promptError ? `Pi RPC prompt failed: ${promptError.message}` : "";
+      const diagnosticText = [summary.diagnosticText, promptDiagnostic].filter(Boolean).join("\n");
       if (!input.streamOutput) {
-        if (summary.diagnosticText) console.error(summary.diagnosticText);
+        if (diagnosticText) console.error(diagnosticText);
         if (summary.completionText) console.log(summary.completionText);
+      } else if (promptDiagnostic && !summary.diagnosticText.includes(promptDiagnostic)) {
+        console.error(promptDiagnostic);
       }
       return {
         completionText: summary.completionText,
-        evidenceText: `${summary.completionText}\n${summary.diagnosticText}`,
+        evidenceText: `${summary.completionText}\n${diagnosticText}`,
         question: summary.question,
         toolCounts,
         exitCode,

--- a/completion.ts
+++ b/completion.ts
@@ -216,11 +216,54 @@ export function extractCursorAgentStreamDisplayLines(rawLine: string): string[] 
   return lines;
 }
 
+export function extractPiStreamDisplayLines(rawLine: string): string[] {
+  const cleanLine = stripAnsi(rawLine).trim();
+  if (!cleanLine.startsWith("{")) {
+    return [rawLine];
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(cleanLine);
+  } catch {
+    return [rawLine];
+  }
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+
+  const event = payload as Record<string, unknown>;
+  if (event.type !== "message_end" || !event.message || typeof event.message !== "object") {
+    return [];
+  }
+
+  const message = event.message as Record<string, unknown>;
+  if (message.role !== "assistant") {
+    return [];
+  }
+
+  const lines: string[] = [];
+  if (typeof message.content === "string") {
+    addNonEmptyTextLines(lines, message.content);
+  } else if (Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (!block || typeof block !== "object") continue;
+      const contentBlock = block as Record<string, unknown>;
+      if (contentBlock.type === "text") {
+        addNonEmptyTextLines(lines, contentBlock.text);
+      }
+    }
+  }
+  return lines;
+}
+
 export function extractAgentCompletionText(output: string, agentType: string): string {
   const extractStreamLines = agentType === "claude-code" || agentType === "qwen-code"
     ? extractClaudeStreamDisplayLines
     : agentType === "cursor-agent"
     ? extractCursorAgentStreamDisplayLines
+    : agentType === "pi"
+    ? extractPiStreamDisplayLines
     : null;
 
   if (!extractStreamLines) return output;

--- a/completion.ts
+++ b/completion.ts
@@ -216,45 +216,185 @@ export function extractCursorAgentStreamDisplayLines(rawLine: string): string[] 
   return lines;
 }
 
-export function extractPiStreamDisplayLines(rawLine: string): string[] {
-  const cleanLine = stripAnsi(rawLine).trim();
+const PI_STREAM_RETAINED_TEXT_LIMIT_BYTES = 64 * 1024;
+const UTF8_ENCODER = new TextEncoder();
+const UTF8_DECODER = new TextDecoder();
+
+interface PiStreamLineEffect {
+  displayLines: string[];
+  toolName: string | null;
+  question: string | null;
+  diagnosticText: string | null;
+}
+
+function extractPiQuestion(args: unknown): string | null {
+  if (!args || typeof args !== "object") return null;
+  const record = args as Record<string, unknown>;
+  for (const key of ["question", "prompt", "message", "text"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim().substring(0, 200);
+  }
+  if (Array.isArray(record.questions)) {
+    const first = record.questions[0];
+    if (first && typeof first === "object") {
+      const value = (first as Record<string, unknown>).question;
+      if (typeof value === "string" && value.trim()) return value.trim().substring(0, 200);
+    }
+  }
+  return null;
+}
+
+function extractPiDiagnostic(value: unknown, depth = 0): string | null {
+  if (depth > 3) return null;
+  if (typeof value === "string") return value.trim() || null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const diagnostic = extractPiDiagnostic(item, depth + 1);
+      if (diagnostic) return diagnostic;
+    }
+    return null;
+  }
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  for (const key of ["message", "errorMessage", "text", "content", "error", "result"]) {
+    const diagnostic = extractPiDiagnostic(record[key], depth + 1);
+    if (diagnostic) return diagnostic;
+  }
+  return null;
+}
+
+function parsePiStreamLine(rawLine: string): PiStreamLineEffect {
+  const emptyEffect = {
+    displayLines: [],
+    toolName: null,
+    question: null,
+    diagnosticText: null,
+  } satisfies PiStreamLineEffect;
+  const cleanLine = rawLine.includes("\x1B[") ? stripAnsi(rawLine).trim() : rawLine.trim();
   if (!cleanLine.startsWith("{")) {
-    return [rawLine];
+    return { ...emptyEffect, displayLines: [rawLine] };
+  }
+
+  // Cumulative Pi events can dwarf useful output, so parse only event types with retained semantics.
+  const typeMatch = cleanLine.match(/^\{\s*"type"\s*:\s*"([^"]+)"/);
+  const eventType = typeMatch?.[1];
+  const failedToolEvent = eventType === "tool_execution_end" &&
+    /"isError"\s*:\s*true(?:\s*[,}])/.test(cleanLine);
+  if (
+    eventType &&
+    eventType !== "message_end" &&
+    eventType !== "tool_execution_start" &&
+    eventType !== "error" &&
+    !failedToolEvent
+  ) {
+    return emptyEffect;
   }
 
   let payload: unknown;
   try {
     payload = JSON.parse(cleanLine);
   } catch {
-    return [rawLine];
+    return eventType
+      ? { ...emptyEffect, diagnosticText: rawLine }
+      : { ...emptyEffect, displayLines: [rawLine] };
   }
-  if (!payload || typeof payload !== "object") {
-    return [];
-  }
+  if (!payload || typeof payload !== "object") return emptyEffect;
 
   const event = payload as Record<string, unknown>;
+  const toolName = event.type === "tool_execution_start" && typeof event.toolName === "string"
+    ? event.toolName
+    : null;
+  const question = toolName?.toLowerCase() === "question"
+    ? extractPiQuestion(event.args) ?? "question detected"
+    : null;
+  const diagnosticText = event.type === "error"
+    ? extractPiDiagnostic(event.error) ?? rawLine
+    : event.type === "tool_execution_end" && event.isError === true
+    ? extractPiDiagnostic(event.result) ?? rawLine
+    : null;
   if (event.type !== "message_end" || !event.message || typeof event.message !== "object") {
-    return [];
+    return { displayLines: [], toolName, question, diagnosticText };
   }
 
   const message = event.message as Record<string, unknown>;
   if (message.role !== "assistant") {
-    return [];
+    return { displayLines: [], toolName, question, diagnosticText };
   }
 
-  const lines: string[] = [];
+  const displayLines: string[] = [];
   if (typeof message.content === "string") {
-    addNonEmptyTextLines(lines, message.content);
+    addNonEmptyTextLines(displayLines, message.content);
   } else if (Array.isArray(message.content)) {
     for (const block of message.content) {
       if (!block || typeof block !== "object") continue;
       const contentBlock = block as Record<string, unknown>;
       if (contentBlock.type === "text") {
-        addNonEmptyTextLines(lines, contentBlock.text);
+        addNonEmptyTextLines(displayLines, contentBlock.text);
       }
     }
   }
-  return lines;
+  return {
+    displayLines,
+    toolName,
+    question,
+    diagnosticText: diagnosticText ?? extractPiDiagnostic(message.errorMessage),
+  };
+}
+
+function appendRetainedText(current: string, text: string): string {
+  const combined = current ? `${current}\n${text}` : text;
+  let candidateStart = Math.max(0, combined.length - PI_STREAM_RETAINED_TEXT_LIMIT_BYTES);
+  if (
+    candidateStart > 0 &&
+    combined.charCodeAt(candidateStart) >= 0xDC00 &&
+    combined.charCodeAt(candidateStart) <= 0xDFFF &&
+    combined.charCodeAt(candidateStart - 1) >= 0xD800 &&
+    combined.charCodeAt(candidateStart - 1) <= 0xDBFF
+  ) {
+    candidateStart--;
+  }
+
+  const candidate = combined.slice(candidateStart);
+  const bytes = UTF8_ENCODER.encode(candidate);
+  if (bytes.byteLength <= PI_STREAM_RETAINED_TEXT_LIMIT_BYTES) return candidate;
+
+  let byteStart = bytes.byteLength - PI_STREAM_RETAINED_TEXT_LIMIT_BYTES;
+  while (byteStart < bytes.byteLength && (bytes[byteStart] & 0xC0) === 0x80) byteStart++;
+  return UTF8_DECODER.decode(bytes.subarray(byteStart));
+}
+
+export function extractPiStreamDisplayLines(rawLine: string): string[] {
+  return parsePiStreamLine(rawLine).displayLines;
+}
+
+export function createPiStreamReducer() {
+  let completionText = "";
+  let diagnosticText = "";
+  let question: string | null = null;
+
+  return {
+    pushLine(rawLine: string, isError: boolean) {
+      const effect = parsePiStreamLine(rawLine);
+      if (isError) {
+        diagnosticText = appendRetainedText(diagnosticText, rawLine);
+      } else {
+        if (effect.diagnosticText) {
+          diagnosticText = appendRetainedText(diagnosticText, effect.diagnosticText);
+        }
+        if (effect.displayLines.length > 0) {
+          completionText = appendRetainedText("", effect.displayLines.join("\n"));
+        }
+      }
+      if (!question && effect.question) {
+        question = effect.question;
+      }
+      return effect;
+    },
+    finish() {
+      return { completionText, diagnosticText, question };
+    },
+  };
 }
 
 export function extractAgentCompletionText(output: string, agentType: string): string {

--- a/loop-control.ts
+++ b/loop-control.ts
@@ -1,0 +1,519 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { createConnection, createServer, type Server, type Socket } from "net";
+import { tmpdir } from "os";
+import { dirname, join, resolve, sep } from "path";
+
+const CONTROL_PROTOCOL_VERSION = 1;
+const MAX_STEERING_TEXT_BYTES = 64 * 1024;
+const MAX_CONTROL_FRAME_BYTES = MAX_STEERING_TEXT_BYTES * 6 + 4096;
+const CONTROL_READ_TIMEOUT_MS = 2_000;
+const STATUS_TIMEOUT_MS = 750;
+
+type SteerFunction = (text: string) => Promise<void>;
+
+type ActiveIteration = {
+  generation: number;
+  agent: string;
+  steer?: SteerFunction;
+};
+
+type ControlDescriptor = {
+  version: number;
+  workspace: string;
+  workspaceHash: string;
+  runId: string;
+  token: string;
+  endpoint: string;
+  pid: number;
+  startedAt: string;
+};
+
+type ControlRequest = {
+  version?: number;
+  type?: string;
+  token?: string;
+  runId?: string;
+  generation?: number;
+  text?: string;
+};
+
+type StatusData = {
+  runId: string;
+  generation: number;
+  agent: string | null;
+  active: boolean;
+  steerable: boolean;
+};
+
+type ControlResponse =
+  | { ok: true; data?: StatusData }
+  | { ok: false; code: string; message: string };
+
+export class LoopControlError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "LoopControlError";
+    this.code = code;
+  }
+}
+
+export interface LoopControl {
+  activate(agent: string, steer?: SteerFunction): () => void;
+  close(): Promise<void>;
+}
+
+function canonicalWorkspace(workspace: string): string {
+  const absolute = resolve(workspace);
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+function workspaceHash(workspace: string): string {
+  return createHash("sha256").update(workspace).digest("hex").slice(0, 16);
+}
+
+function controlRoot(): string {
+  if (process.env.RALPH_CONTROL_DIR) return resolve(process.env.RALPH_CONTROL_DIR);
+  const user = typeof process.getuid === "function" ? process.getuid() : process.env.USERNAME || "user";
+  return join(tmpdir(), `ralph-wiggum-${user}`);
+}
+
+function ensurePrivateDirectory(path: string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32") chmodSync(path, 0o700);
+}
+
+function descriptorPath(root: string, hash: string, runId: string): string {
+  return join(root, `${hash}-${runId}.json`);
+}
+
+function endpointPath(root: string, hash: string, runId: string): string {
+  if (process.platform === "win32") return `\\\\.\\pipe\\ralph-${hash}-${runId}`;
+  let socketRoot = root;
+  let endpoint = join(socketRoot, `${hash}-${runId.slice(0, 8)}.sock`);
+  if (Buffer.byteLength(endpoint) > 100) {
+    const user = typeof process.getuid === "function" ? process.getuid() : "user";
+    socketRoot = join("/tmp", `rw-${user}`);
+    ensurePrivateDirectory(socketRoot);
+    endpoint = join(socketRoot, `${hash}-${runId.slice(0, 8)}.sock`);
+  }
+  if (Buffer.byteLength(endpoint) > 100) {
+    throw new LoopControlError("control-path-too-long", "Unable to create a short Ralph control socket path.");
+  }
+  return endpoint;
+}
+
+function safeTokenEquals(received: unknown, expected: string): boolean {
+  if (typeof received !== "string") return false;
+  const receivedBytes = Buffer.from(received);
+  const expectedBytes = Buffer.from(expected);
+  return receivedBytes.length === expectedBytes.length && timingSafeEqual(receivedBytes, expectedBytes);
+}
+
+function errorResponse(error: unknown): ControlResponse {
+  if (error instanceof LoopControlError) {
+    return { ok: false, code: error.code, message: error.message };
+  }
+  return { ok: false, code: "steer-failed", message: "The current iteration rejected steering." };
+}
+
+function responseError(response: Extract<ControlResponse, { ok: false }>): LoopControlError {
+  return new LoopControlError(response.code, response.message);
+}
+
+function writeDescriptor(path: string, descriptor: ControlDescriptor): void {
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporary, JSON.stringify(descriptor), { encoding: "utf-8", mode: 0o600, flag: "wx" });
+    renameSync(temporary, path);
+    if (process.platform !== "win32") chmodSync(path, 0o600);
+  } finally {
+    if (existsSync(temporary)) rmSync(temporary, { force: true });
+  }
+}
+
+function removeDescriptorIfUnchanged(path: string, expectedContent: string, endpoint?: string): void {
+  try {
+    if (readFileSync(path, "utf-8") !== expectedContent) return;
+    unlinkSync(path);
+    if (process.platform === "win32" || !endpoint) return;
+
+    const user = typeof process.getuid === "function" ? process.getuid() : "user";
+    const allowedRoots = [resolve(dirname(path)), resolve(join("/tmp", `rw-${user}`))];
+    const resolvedEndpoint = resolve(endpoint);
+    const ownedPath = allowedRoots.some(root => resolvedEndpoint.startsWith(`${root}${sep}`));
+    if (ownedPath && lstatSync(resolvedEndpoint).isSocket()) rmSync(resolvedEndpoint, { force: true });
+  } catch {}
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise(resolvePromise => {
+    if (!server.listening) {
+      resolvePromise();
+      return;
+    }
+    server.close(() => resolvePromise());
+  });
+}
+
+function listen(server: Server, endpoint: string): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      rejectPromise(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolvePromise();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(endpoint);
+  });
+}
+
+export async function startLoopControl(workspaceInput: string): Promise<LoopControl> {
+  const workspace = canonicalWorkspace(workspaceInput);
+  const hash = workspaceHash(workspace);
+  const root = controlRoot();
+  ensurePrivateDirectory(root);
+
+  const runId = randomUUID();
+  const token = randomBytes(32).toString("hex");
+  const endpoint = endpointPath(root, hash, runId);
+  const descriptorFile = descriptorPath(root, hash, runId);
+  let generation = 0;
+  let current: ActiveIteration | null = null;
+  let closed = false;
+  let closePromise: Promise<void> | null = null;
+  const sockets = new Set<Socket>();
+
+  const handleRequest = async (request: ControlRequest): Promise<ControlResponse> => {
+    if (request.version !== CONTROL_PROTOCOL_VERSION) {
+      throw new LoopControlError("protocol-version", "Unsupported Ralph control protocol version.");
+    }
+    if (!safeTokenEquals(request.token, token) || request.runId !== runId) {
+      throw new LoopControlError("unauthorized", "Ralph control authentication failed.");
+    }
+
+    if (request.type === "status") {
+      return {
+        ok: true,
+        data: {
+          runId,
+          generation: current?.generation ?? generation,
+          agent: current?.agent ?? null,
+          active: current !== null,
+          steerable: !!current?.steer,
+        },
+      };
+    }
+
+    if (request.type !== "steer") {
+      throw new LoopControlError("invalid-request", "Unknown Ralph control request.");
+    }
+    if (typeof request.text !== "string" || !request.text.trim()) {
+      throw new LoopControlError("invalid-steer", "Steering text must not be empty.");
+    }
+    if (Buffer.byteLength(request.text) > MAX_STEERING_TEXT_BYTES) {
+      throw new LoopControlError("message-too-large", "Steering text exceeds the 64 KiB limit.");
+    }
+    if (!current) {
+      throw new LoopControlError("no-active-iteration", "No agent iteration is currently active.");
+    }
+    if (request.generation !== current.generation) {
+      throw new LoopControlError("iteration-changed", "The active iteration changed before steering was delivered.");
+    }
+    if (!current.steer) {
+      throw new LoopControlError(
+        "unsupported-agent",
+        `Current agent "${current.agent}" does not support current-iteration steering. Use --add-context for the next iteration.`,
+      );
+    }
+
+    const steer = current.steer;
+    try {
+      await steer(request.text);
+      return { ok: true };
+    } catch {
+      throw new LoopControlError("iteration-ended", "The Pi iteration ended before steering was delivered.");
+    }
+  };
+
+  const server = createServer(socket => {
+    sockets.add(socket);
+    let requestBuffer = Buffer.alloc(0);
+    let requestReceived = false;
+    let finished = false;
+    const finish = (response: ControlResponse) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      if (!socket.destroyed) socket.end(JSON.stringify(response));
+    };
+    const timer = setTimeout(() => {
+      finish({ ok: false, code: "request-timeout", message: "Ralph control request timed out." });
+    }, CONTROL_READ_TIMEOUT_MS);
+
+    socket.on("data", chunk => {
+      if (finished || requestReceived) return;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      requestBuffer = Buffer.concat([requestBuffer, buffer]);
+      if (requestBuffer.length > MAX_CONTROL_FRAME_BYTES) {
+        finish({ ok: false, code: "message-too-large", message: "Ralph control request is too large." });
+        return;
+      }
+
+      const newline = requestBuffer.indexOf(0x0a);
+      if (newline === -1) return;
+      requestReceived = true;
+      clearTimeout(timer);
+      const trailing = requestBuffer.subarray(newline + 1).toString("utf-8").trim();
+      if (trailing) {
+        finish({ ok: false, code: "invalid-request", message: "Only one Ralph control request is allowed." });
+        return;
+      }
+
+      void (async () => {
+        try {
+          const text = requestBuffer.subarray(0, newline).toString("utf-8").replace(/\r$/, "");
+          const parsed = JSON.parse(text);
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            throw new LoopControlError("invalid-request", "Ralph control request must be a JSON object.");
+          }
+          finish(await handleRequest(parsed as ControlRequest));
+        } catch (error) {
+          finish(errorResponse(error));
+        }
+      })();
+    });
+
+    socket.on("end", () => {
+      if (!requestReceived && !finished) {
+        finish({ ok: false, code: "invalid-request", message: "Incomplete Ralph control request." });
+      }
+    });
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+  });
+  server.on("error", () => {});
+
+  try {
+    await listen(server, endpoint);
+    if (process.platform !== "win32") chmodSync(endpoint, 0o600);
+    writeDescriptor(descriptorFile, {
+      version: CONTROL_PROTOCOL_VERSION,
+      workspace,
+      workspaceHash: hash,
+      runId,
+      token,
+      endpoint,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    await closeServer(server);
+    if (process.platform !== "win32") rmSync(endpoint, { force: true });
+    throw error;
+  }
+
+  return {
+    activate(agent: string, steer?: SteerFunction): () => void {
+      if (closed) throw new LoopControlError("control-closed", "Ralph loop control is closed.");
+      const active: ActiveIteration = { generation: ++generation, agent, steer };
+      current = active;
+      return () => {
+        if (current === active) current = null;
+      };
+    },
+
+    close(): Promise<void> {
+      if (closePromise) return closePromise;
+      closed = true;
+      current = null;
+      generation++;
+      closePromise = (async () => {
+        for (const socket of sockets) socket.destroy();
+        await closeServer(server);
+        try {
+          const content = readFileSync(descriptorFile, "utf-8");
+          const descriptor = JSON.parse(content) as ControlDescriptor;
+          if (descriptor.runId === runId && descriptor.token === token) unlinkSync(descriptorFile);
+        } catch {}
+        if (process.platform !== "win32") rmSync(endpoint, { force: true });
+      })();
+      return closePromise;
+    },
+  };
+}
+
+function readDescriptors(workspace: string): Array<{
+  path: string;
+  content: string;
+  descriptor: ControlDescriptor;
+}> {
+  const root = controlRoot();
+  ensurePrivateDirectory(root);
+  const hash = workspaceHash(workspace);
+  const prefix = `${hash}-`;
+  const descriptors: Array<{ path: string; content: string; descriptor: ControlDescriptor }> = [];
+
+  for (const name of readdirSync(root)) {
+    if (!name.startsWith(prefix) || !name.endsWith(".json")) continue;
+    const path = join(root, name);
+    try {
+      if (!lstatSync(path).isFile()) continue;
+      const content = readFileSync(path, "utf-8");
+      const descriptor = JSON.parse(content) as ControlDescriptor;
+      if (
+        descriptor.version !== CONTROL_PROTOCOL_VERSION ||
+        descriptor.workspace !== workspace ||
+        descriptor.workspaceHash !== hash ||
+        typeof descriptor.runId !== "string" ||
+        typeof descriptor.token !== "string" ||
+        typeof descriptor.endpoint !== "string"
+      ) {
+        continue;
+      }
+      descriptors.push({ path, content, descriptor });
+    } catch {}
+  }
+  return descriptors;
+}
+
+function sendRequest(
+  descriptor: ControlDescriptor,
+  request: Omit<ControlRequest, "version" | "token" | "runId">,
+  timeoutMs: number,
+): Promise<ControlResponse> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const socket = createConnection(descriptor.endpoint);
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let completed = false;
+    const timer = timeoutMs > 0
+      ? setTimeout(() => finishError(new Error("Ralph control connection timed out")), timeoutMs)
+      : null;
+
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      socket.removeAllListeners();
+    };
+    const finishError = (error: Error) => {
+      if (completed) return;
+      completed = true;
+      cleanup();
+      socket.destroy();
+      rejectPromise(error);
+    };
+    const finishResponse = () => {
+      if (completed) return;
+      completed = true;
+      cleanup();
+      try {
+        const response = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as ControlResponse;
+        if (!response || typeof response !== "object" || typeof response.ok !== "boolean") {
+          throw new Error("Invalid Ralph control response");
+        }
+        resolvePromise(response);
+      } catch (error) {
+        rejectPromise(error instanceof Error ? error : new Error(String(error)));
+      }
+    };
+
+    socket.on("connect", () => {
+      socket.write(`${JSON.stringify({
+        version: CONTROL_PROTOCOL_VERSION,
+        token: descriptor.token,
+        runId: descriptor.runId,
+        ...request,
+      })}\n`);
+    });
+    socket.on("data", chunk => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buffer.length;
+      if (size > MAX_CONTROL_FRAME_BYTES) {
+        finishError(new Error("Ralph control response is too large"));
+        return;
+      }
+      chunks.push(buffer);
+    });
+    socket.on("end", finishResponse);
+    socket.on("error", finishError);
+  });
+}
+
+export async function steerCurrentIteration(workspaceInput: string, text: string): Promise<void> {
+  if (!text.trim()) throw new LoopControlError("invalid-steer", "Steering text must not be empty.");
+  if (Buffer.byteLength(text) > MAX_STEERING_TEXT_BYTES) {
+    throw new LoopControlError("message-too-large", "Steering text exceeds the 64 KiB limit.");
+  }
+
+  const workspace = canonicalWorkspace(workspaceInput);
+  const descriptors = readDescriptors(workspace);
+  const online: Array<{ descriptor: ControlDescriptor; status: StatusData }> = [];
+
+  for (const candidate of descriptors) {
+    try {
+      const response = await sendRequest(candidate.descriptor, { type: "status" }, STATUS_TIMEOUT_MS);
+      if (!response.ok) throw responseError(response);
+      if (!response.data || response.data.runId !== candidate.descriptor.runId) {
+        throw new Error("Ralph control identity mismatch");
+      }
+      online.push({ descriptor: candidate.descriptor, status: response.data });
+    } catch {
+      removeDescriptorIfUnchanged(candidate.path, candidate.content, candidate.descriptor.endpoint);
+    }
+  }
+
+  if (online.length === 0) {
+    throw new LoopControlError("no-active-loop", `No active Ralph loop was found for ${workspace}.`);
+  }
+  if (online.length > 1) {
+    throw new LoopControlError(
+      "ambiguous-loop",
+      `Multiple active Ralph loops were found for ${workspace}; steering was not sent.`,
+    );
+  }
+
+  const [{ descriptor, status }] = online;
+  if (!status.active) {
+    throw new LoopControlError("no-active-iteration", "No agent iteration is currently active.");
+  }
+  if (!status.steerable) {
+    throw new LoopControlError(
+      "unsupported-agent",
+      `Current agent "${status.agent ?? "unknown"}" does not support current-iteration steering. Use --add-context for the next iteration.`,
+    );
+  }
+
+  let response: ControlResponse;
+  try {
+    response = await sendRequest(
+      descriptor,
+      { type: "steer", generation: status.generation, text },
+      0,
+    );
+  } catch {
+    throw new LoopControlError("control-unavailable", "The active Ralph loop became unavailable.");
+  }
+  if (!response.ok) throw responseError(response);
+}

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   "scripts": {
     "start": "bun ralph.ts",
     "build": "bun build ralph.ts --outfile bin/ralph --compile",
-    "test": "bun test ./tests/ralph.test.ts",
+    "test": "bun test ./tests",
     "install-local": "bun link"
   },
   "files": [
     "bin/ralph.js",
     "ralph.ts",
+    "agent-iteration.ts",
+    "loop-control.ts",
     "completion.ts",
     "README.md",
     "LICENSE",

--- a/ralph.ts
+++ b/ralph.ts
@@ -9,13 +9,11 @@
 import { $ } from "bun";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "fs";
 import { join } from "path";
+import { startAgentIteration } from "./agent-iteration";
+import { LoopControlError, startLoopControl, steerCurrentIteration } from "./loop-control";
 import {
   checkTerminalPromise,
   containsPromiseTag,
-  createPiStreamReducer,
-  extractAgentCompletionText,
-  extractClaudeStreamDisplayLines,
-  extractCursorAgentStreamDisplayLines,
   stripAnsi,
   tasksMarkdownAllComplete,
 } from "./completion";
@@ -195,12 +193,10 @@ const ARGS_TEMPLATES: Record<string, (prompt: string, model: string, options?: A
     if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
     return cmdArgs;
   },
-  "pi": (prompt, model, options) => {
-    const cmdArgs = ["-p", "--no-session"];
-    if (options?.streamOutput) cmdArgs.push("--mode", "json");
+  "pi": (_prompt, model, options) => {
+    const cmdArgs = ["--mode", "rpc", "--no-session"];
     if (model) cmdArgs.push("--model", model);
     if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
-    cmdArgs.push(prompt);
     return cmdArgs;
   },
   "default": (prompt, model, options) => {
@@ -367,6 +363,26 @@ if (customAgents) {
   }
 }
 
+// Handle current-iteration steering before normal loop option parsing.
+const steerIdx = args.indexOf("--steer");
+if (steerIdx !== -1) {
+  const steerText = args[steerIdx + 1];
+  if (!steerText || steerText.startsWith("--")) {
+    console.error("Error: --steer requires text for the current Pi iteration");
+    console.error('Usage: ralph --steer "Your steering instruction"');
+    process.exit(1);
+  }
+  try {
+    await steerCurrentIteration(process.cwd(), steerText);
+    console.log("Steering delivered to the active Pi iteration.");
+    process.exit(0);
+  } catch (error) {
+    const message = error instanceof LoopControlError ? error.message : "Unable to steer the active Ralph loop.";
+    console.error(`Error: ${message}`);
+    process.exit(1);
+  }
+}
+
 // Handle --config and --init-config flags before other processing
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "--config") {
@@ -443,6 +459,7 @@ Commands:
   --status            Show current Ralph loop status and history
   --status --tasks    Show status including current task list
   --add-context TEXT  Add context for the next iteration (or edit .ralph/ralph-context.md)
+  --steer TEXT        Steer the current Pi iteration at its next safe turn boundary
   --clear-context     Clear any pending context
   --list-tasks        Display the current task list with indices
   --add-task "desc"   Add a new task to the list
@@ -457,6 +474,7 @@ Examples:
   ralph --prompt-file ./prompt.md --max-iterations 5
   ralph --status                                        # Check loop status
   ralph --add-context "Focus on the auth module first"  # Add hint for next iteration
+  ralph --steer "Inspect the failing test first"         # Steer the current Pi iteration
   ralph "Build API" -- --agent build                    # Pass flags to the agent
 
 How it works:
@@ -1993,24 +2011,6 @@ function formatToolSummary(toolCounts: Map<string, number>, maxItems = 6): strin
   return parts.join(" • ");
 }
 
-function collectToolSummaryFromText(text: string, agent: AgentConfig): Map<string, number> {
-  const counts = new Map<string, number>();
-  const lines = text.split(/\r?\n/);
-  for (const line of lines) {
-    const tool = agent.parseToolOutput(line);
-    if (tool) {
-      counts.set(tool, (counts.get(tool) ?? 0) + 1);
-    }
-  }
-  return counts;
-}
-
-function terminateProcess(proc: ReturnType<typeof Bun.spawn>, signal: NodeJS.Signals = "SIGTERM"): void {
-  try {
-    proc.kill(signal);
-  } catch {}
-}
-
 function printIterationSummary(params: {
   iteration: number;
   elapsedMs: number;
@@ -2036,197 +2036,6 @@ function printIterationSummary(params: {
   console.log(`Completion promise: ${params.completionDetected ? "detected" : "not detected"}`);
 }
 
-async function streamProcessOutput(
-  proc: ReturnType<typeof Bun.spawn>,
-  options: {
-    compactTools: boolean;
-    toolSummaryIntervalMs: number;
-    heartbeatIntervalMs: number;
-    iterationStart: number;
-    agent: AgentConfig;
-    onHeartbeatTimer?: (timer: ReturnType<typeof setInterval>) => void;
-    abortSignal?: AbortSignal;
-    lastActivityTimeoutMs?: number;
-    onActivityTimeout?: () => void;
-  },
-): Promise<{
-  stdoutText: string;
-  stderrText: string;
-  question: string | null;
-  toolCounts: Map<string, number>;
-}> {
-  const toolCounts = new Map<string, number>();
-  let stdoutText = "";
-  let stderrText = "";
-  let lastPrintedAt = Date.now();
-  let lastActivityAt = Date.now();
-  let lastToolSummaryAt = 0;
-  let activityTimedOut = false;
-
-  const compactTools = options.compactTools;
-  const parseToolOutput = options.agent.parseToolOutput;
-  const piReducer = options.agent.type === "pi" ? createPiStreamReducer() : null;
-
-  const maybePrintToolSummary = (force = false) => {
-    if (!compactTools || toolCounts.size === 0) return;
-    const now = Date.now();
-    if (!force && now - lastToolSummaryAt < options.toolSummaryIntervalMs) {
-      return;
-    }
-    const summary = formatToolSummary(toolCounts);
-    if (summary) {
-      console.log(`| Tools    ${summary}`);
-      lastPrintedAt = Date.now();
-      lastToolSummaryAt = Date.now();
-    }
-  };
-
-  const handleLine = (line: string, isError: boolean) => {
-    lastActivityAt = Date.now();
-    const piEffect = piReducer?.pushLine(line, isError);
-    const tool = piEffect ? piEffect.toolName : parseToolOutput(line);
-    const outputLines = piEffect?.displayLines ?? (
-      options.agent.type === "claude-code" || options.agent.type === "qwen-code"
-        ? extractClaudeStreamDisplayLines(line)
-        : options.agent.type === "cursor-agent"
-        ? extractCursorAgentStreamDisplayLines(line)
-        : [line]
-    );
-    if (tool) {
-      toolCounts.set(tool, (toolCounts.get(tool) ?? 0) + 1);
-      if (compactTools && outputLines.length === 0) {
-        maybePrintToolSummary();
-        return;
-      }
-    }
-
-    for (const outputLine of outputLines) {
-      if (outputLine.length === 0) {
-        console.log("");
-        lastPrintedAt = Date.now();
-        continue;
-      }
-      if (isError) {
-        console.error(outputLine);
-      } else {
-        console.log(outputLine);
-      }
-      lastPrintedAt = Date.now();
-    }
-  };
-
-  const streamText = async (
-    stream: ReadableStream<Uint8Array> | null,
-    onText: (chunk: string) => void,
-    isError: boolean,
-  ) => {
-    if (!stream) return;
-    const reader = stream.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    
-    // Create abort promise if signal provided
-    const abortPromise = options.abortSignal
-      ? new Promise<{ value: undefined; done: true }>((resolve, reject) => {
-          const handler = () => {
-            options.abortSignal?.removeEventListener('abort', handler);
-            resolve({ value: undefined, done: true });
-          };
-          options.abortSignal.addEventListener('abort', handler);
-        })
-      : new Promise<{ value: undefined; done: true }>(() => {});
-    
-    while (true) {
-      const result = options.abortSignal
-        ? await Promise.race([reader.read(), abortPromise])
-        : await reader.read();
-      
-      const { value, done } = result;
-      if (done) break;
-      const text = decoder.decode(value, { stream: true });
-      if (text.length > 0) {
-        onText(text);
-        buffer += text;
-        const lines = buffer.split(/\r?\n/);
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          handleLine(line, isError);
-        }
-      }
-    }
-    const flushed = decoder.decode();
-    if (flushed.length > 0) {
-      onText(flushed);
-      buffer += flushed;
-    }
-    if (buffer.length > 0) {
-      handleLine(buffer, isError);
-    }
-  };
-
-  const heartbeatTimer = setInterval(() => {
-    const now = Date.now();
-    if (now - lastPrintedAt >= options.heartbeatIntervalMs) {
-      const elapsed = formatDuration(now - options.iterationStart);
-      const sinceActivity = formatDuration(now - lastActivityAt);
-      console.log(`⏳ working... elapsed ${elapsed} · last activity ${sinceActivity} ago`);
-      lastPrintedAt = now;
-    }
-    // Check for inactivity timeout
-    if (!activityTimedOut && options.lastActivityTimeoutMs && options.lastActivityTimeoutMs > 0) {
-      const inactivityMs = now - lastActivityAt;
-      if (inactivityMs >= options.lastActivityTimeoutMs) {
-        activityTimedOut = true;
-        const timeoutDuration = formatDuration(options.lastActivityTimeoutMs);
-        console.log(`\n⏰ Inactivity timeout: no activity for ${timeoutDuration}. Restarting iteration...`);
-        options.onActivityTimeout?.();
-      }
-    }
-  }, options.heartbeatIntervalMs);
-  
-  // Notify caller of heartbeat timer for cleanup
-  if (options.onHeartbeatTimer) {
-    options.onHeartbeatTimer(heartbeatTimer);
-  }
-
-  try {
-    await Promise.all([
-      streamText(
-        proc.stdout,
-        chunk => {
-          if (!piReducer) stdoutText += chunk;
-        },
-        false,
-      ),
-      streamText(
-        proc.stderr,
-        chunk => {
-          if (!piReducer) stderrText += chunk;
-        },
-        true,
-      ),
-    ]);
-  } finally {
-    clearInterval(heartbeatTimer);
-  }
-
-  if (compactTools) {
-    maybePrintToolSummary(true);
-  }
-
-  const piSummary = piReducer?.finish();
-  if (piSummary) {
-    stdoutText = piSummary.completionText;
-    stderrText = piSummary.diagnosticText;
-  }
-
-  return {
-    stdoutText,
-    stderrText,
-    question: piSummary?.question ?? null,
-    toolCounts,
-  };
-}
 // Main loop
 // Helper to detect per-iteration file changes using content hashes
 // Works correctly with --no-commit by comparing file content hashes
@@ -2421,6 +2230,8 @@ async function runRalphLoop(): Promise<void> {
     codexGoalForceNative: codexGoalForceNative || undefined,
   };
 
+  const loopControl = await startLoopControl(process.cwd());
+
   if (!resuming) {
     saveState(state);
   }
@@ -2487,54 +2298,42 @@ async function runRalphLoop(): Promise<void> {
   console.log("Starting loop... (Ctrl+C to stop)");
   console.log("═".repeat(68));
 
-  // Track current subprocess for cleanup on SIGINT
-  let currentProc: ReturnType<typeof Bun.spawn> | null = null;
+  // The active iteration owns its child process, readers, and heartbeat timer.
+  let currentIterationAbortController: AbortController | null = null;
 
-  // Track current heartbeat timer for cleanup on SIGINT
-  let currentHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
-
-  // Track current AbortController for cancelling stream reading
-  let currentAbortController: AbortController | null = null;
-
-  // Set up signal handler for graceful shutdown
+  // Set up signal handlers for graceful shutdown.
   let stopping = false;
-  process.on("SIGINT", () => {
+  const stopLoop = (signal: "SIGINT" | "SIGTERM") => {
     if (stopping) {
-      console.log("\nForce stopping...");
-      process.exit(1);
+      if (signal === "SIGINT") {
+        console.log("\nForce stopping...");
+        process.exit(1);
+      }
+      return;
     }
     stopping = true;
     console.log("\nGracefully stopping Ralph loop...");
 
-    // Abort any pending stream operations
-    if (currentAbortController) {
-      currentAbortController.abort();
-      currentAbortController = null;
-    }
-
-    // Clear the heartbeat timer immediately to stop status messages
-    if (currentHeartbeatTimer) {
-      clearInterval(currentHeartbeatTimer);
-      currentHeartbeatTimer = null;
-    }
-
-    // Kill the subprocess if it's running
-    if (currentProc) {
-      terminateProcess(currentProc);
+    if (currentIterationAbortController) {
+      currentIterationAbortController.abort();
+      currentIterationAbortController = null;
     }
 
     clearState();
     clearPendingQuestions();
     console.log("Loop cancelled.");
-    
-    // Use setImmediate to allow the abort event to propagate
-    // then force exit. This is more reliable than process.exit()
-    // directly in the signal handler with pending async operations.
-    setImmediate(() => process.exit(0));
-  });
+
+    const exitCode = signal === "SIGTERM" ? 143 : 0;
+    void loopControl.close().finally(() => {
+      setImmediate(() => process.exit(exitCode));
+    });
+  };
+  process.on("SIGINT", () => stopLoop("SIGINT"));
+  process.on("SIGTERM", () => stopLoop("SIGTERM"));
 
   // Main loop
-  while (true) {
+  try {
+    while (true) {
     // Check max iterations
     if (maxIterations > 0 && state.iteration > maxIterations) {
       console.log(`\n╔══════════════════════════════════════════════════════════════════╗`);
@@ -2627,67 +2426,30 @@ async function runRalphLoop(): Promise<void> {
         allowAllPermissions: allowAllPermissions,
       });
 
-      // Run agent using spawn for better argument handling
-      // stdin is inherited so users can respond to permission prompts if needed
-      currentProc = Bun.spawn([command, ...cmdArgs], {
+      const iterationAbortController = new AbortController();
+      currentIterationAbortController = iterationAbortController;
+      const iteration = startAgentIteration({
+        agent: { ...agentConfig, command },
+        args: cmdArgs,
         cwd: process.cwd(),
         env,
-        stdin: "inherit",
-        stdout: "pipe",
-        stderr: "pipe",
+        prompt: fullPrompt,
+        streamOutput,
+        compactTools: !verboseTools,
+        iterationStart,
+        lastActivityTimeoutMs,
+        signal: iterationAbortController.signal,
       });
-      const proc = currentProc;
-      const exitCodePromise = proc.exited;
-      let result = "";
-      let stderr = "";
-      let streamedQuestion: string | null = null;
-      let toolCounts = new Map<string, number>();
-
-      if (streamOutput) {
-        // Create AbortController for this iteration
-        const abortController = new AbortController();
-        currentAbortController = abortController;
-        
-        const streamed = await streamProcessOutput(proc, {
-          compactTools: !verboseTools,
-          toolSummaryIntervalMs: 3000,
-          heartbeatIntervalMs: process.env.NODE_ENV === 'test' ? 1000 : 10000,
-          iterationStart,
-          agent: agentConfig,
-          abortSignal: abortController.signal,
-          lastActivityTimeoutMs,
-          onActivityTimeout: () => {
-            terminateProcess(proc);
-            abortController.abort();
-          },
-          onHeartbeatTimer: (timer) => {
-            currentHeartbeatTimer = timer;
-          },
-        });
-        currentHeartbeatTimer = null; // Clear after streaming completes
-        currentAbortController = null; // Clear after streaming completes
-        result = streamed.stdoutText;
-        stderr = streamed.stderrText;
-        streamedQuestion = streamed.question;
-        toolCounts = streamed.toolCounts;
-      } else {
-        const stdoutPromise = new Response(proc.stdout).text();
-        const stderrPromise = new Response(proc.stderr).text();
-        [result, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
-        toolCounts = collectToolSummaryFromText(`${result}\n${stderr}`, agentConfig);
+      const deactivateControl = loopControl.activate(currentAgent, iteration.steer);
+      const iterationResult = await iteration.settled.finally(deactivateControl);
+      if (currentIterationAbortController === iterationAbortController) {
+        currentIterationAbortController = null;
       }
 
-      const exitCode = await exitCodePromise;
-      currentProc = null; // Clear reference after subprocess completes
-
-      if (!streamOutput) {
-        if (stderr) {
-          console.error(stderr);
-        }
-        console.log(result);
-      }
-
-      const combinedOutput = `${result}\n${stderr}`;
+      const streamedQuestion = iterationResult.question;
+      const toolCounts = iterationResult.toolCounts;
+      const exitCode = iterationResult.exitCode;
+      const combinedOutput = iterationResult.evidenceText;
 
       if (codexGoalMode && currentAgent === "codex" && codexGoalPromptMode === "native") {
         const confirmed = nativeGoalEvidenceDetected(combinedOutput);
@@ -2705,17 +2467,16 @@ async function runRalphLoop(): Promise<void> {
         });
       }
 
-      // Pi streaming has already reduced JSON events to assistant text; buffered Pi output is plain text.
-      const completionCheckText = agentConfig.type === "pi"
-        ? result
-        : extractAgentCompletionText(result, agentConfig.type);
-      // Pi JSON includes user and tool events, so only extracted assistant text may signal a promise.
-      const rawPromiseOutput = agentConfig.type === "pi" ? undefined : result;
+      const acceptsCompletionSignals = agentConfig.type !== "pi" || iterationResult.termination === "agent-settled";
+      const completionCheckText = acceptsCompletionSignals ? iterationResult.completionText : "";
+      const rawPromiseOutput = acceptsCompletionSignals ? iterationResult.rawPromiseText : undefined;
 
       const completionSignalDetected = checkCompletion(completionCheckText, completionPromise, rawPromiseOutput);
       const abortDetected = abortPromise ? checkCompletion(completionCheckText, abortPromise, rawPromiseOutput) : false;
       let taskCompletionDetected = tasksMode ? checkCompletion(completionCheckText, taskPromise, rawPromiseOutput) : false;
-      const taskGateCompletion = taskCompletionDetected ? { satisfied: false } : taskCompletionSatisfiedByTaskGate(state);
+      const taskGateCompletion = acceptsCompletionSignals && !taskCompletionDetected
+        ? taskCompletionSatisfiedByTaskGate(state)
+        : { satisfied: false };
       if (taskGateCompletion.satisfied) {
         taskCompletionDetected = true;
       }
@@ -2828,7 +2589,8 @@ async function runRalphLoop(): Promise<void> {
           "Remove 'ralph-wiggum' from your opencode.json plugin list, or re-run with --no-plugins.",
         );
         clearState();
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       // Detect model configuration errors (Issues #22, #23).
@@ -2850,7 +2612,12 @@ async function runRalphLoop(): Promise<void> {
         }
         console.error("\n   See the agent's documentation for available models.");
         clearState();
-        process.exit(1);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (agentConfig.type === "pi" && iterationResult.termination !== "agent-settled") {
+        console.warn("\n⚠️  Pi RPC process exited before agent_settled. Completion signals were ignored.");
       }
 
       if (exitCode !== 0) {
@@ -2868,7 +2635,8 @@ async function runRalphLoop(): Promise<void> {
         clearHistory();
         clearContext();
         clearPendingQuestions();
-        process.exit(1); // Exit with error code to indicate abort
+        process.exitCode = 1;
+        return; // Exit with error code to indicate abort
       }
 
       // Check for question tool invocation and prompt user if needed
@@ -2986,22 +2754,9 @@ async function runRalphLoop(): Promise<void> {
       await new Promise(r => setTimeout(r, 1000));
 
     } catch (error) {
-      // Clear heartbeat timer if still running
-      if (currentHeartbeatTimer) {
-        clearInterval(currentHeartbeatTimer);
-        currentHeartbeatTimer = null;
-      }
-      
-      // Abort any pending stream operations
-      if (currentAbortController) {
-        currentAbortController.abort();
-        currentAbortController = null;
-      }
-      
-      // Kill subprocess if still running to prevent orphaned processes
-      if (currentProc) {
-        terminateProcess(currentProc);
-        currentProc = null;
+      if (currentIterationAbortController) {
+        currentIterationAbortController.abort();
+        currentIterationAbortController = null;
       }
       console.error(`\n❌ Error in iteration ${state.iteration}:`, error);
       console.log("Continuing to next iteration...");
@@ -3031,7 +2786,14 @@ async function runRalphLoop(): Promise<void> {
       state.iteration++;
       saveState(state);
       await new Promise(r => setTimeout(r, 2000));
+      }
     }
+  } finally {
+    if (currentIterationAbortController) {
+      currentIterationAbortController.abort();
+      currentIterationAbortController = null;
+    }
+    await loopControl.close();
   }
 }
 

--- a/ralph.ts
+++ b/ralph.ts
@@ -15,6 +15,7 @@ import {
   extractAgentCompletionText,
   extractClaudeStreamDisplayLines,
   extractCursorAgentStreamDisplayLines,
+  extractPiStreamDisplayLines,
   stripAnsi,
   tasksMarkdownAllComplete,
 } from "./completion";
@@ -119,6 +120,17 @@ const PARSE_PATTERNS: Record<string, (line: string) => string | null> = {
     }
     return null;
   },
+  "pi": (line) => {
+    const cleanLine = stripAnsi(line).trim();
+    if (!cleanLine.startsWith("{")) return null;
+    try {
+      const payload = JSON.parse(cleanLine);
+      if (payload?.type === "tool_execution_start" && typeof payload.toolName === "string") {
+        return payload.toolName;
+      }
+    } catch {}
+    return null;
+  },
   "codex": null,
   "copilot": null,
   "default": (line) => {
@@ -185,6 +197,7 @@ const ARGS_TEMPLATES: Record<string, (prompt: string, model: string, options?: A
   },
   "pi": (prompt, model, options) => {
     const cmdArgs = ["-p", "--no-session"];
+    if (options?.streamOutput) cmdArgs.push("--mode", "json");
     if (model) cmdArgs.push("--model", model);
     if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
     cmdArgs.push(prompt);
@@ -259,7 +272,7 @@ function getDefaultConfig(): RalphConfig {
       { type: "copilot", command: "copilot", configName: "Copilot CLI", argsTemplate: "copilot", envTemplate: "default", parsePattern: "copilot" },
       { type: "cursor-agent", command: "cursor-agent", configName: "Cursor Agent", argsTemplate: "cursor-agent", envTemplate: "default", parsePattern: "cursor-agent" },
       { type: "qwen-code", command: "qwen", configName: "Qwen Code", argsTemplate: "qwen-code", envTemplate: "default", parsePattern: "qwen-code" },
-      { type: "pi", command: "pi", configName: "Pi", argsTemplate: "pi", envTemplate: "default", parsePattern: "default" },
+      { type: "pi", command: "pi", configName: "Pi", argsTemplate: "pi", envTemplate: "default", parsePattern: "pi" },
     ],
   };
 }
@@ -338,7 +351,7 @@ const BUILT_IN_AGENTS: Record<AgentType, AgentConfig> = {
     command: resolveCommand("pi", process.env.RALPH_PI_BINARY),
     buildArgs: ARGS_TEMPLATES["pi"],
     buildEnv: ENV_TEMPLATES["default"],
-    parseToolOutput: PARSE_PATTERNS["default"],
+    parseToolOutput: PARSE_PATTERNS["pi"],
     configName: "Pi",
   },
 };
@@ -2069,6 +2082,8 @@ async function streamProcessOutput(
       ? extractClaudeStreamDisplayLines(line)
       : options.agent.type === "cursor-agent"
       ? extractCursorAgentStreamDisplayLines(line)
+      : options.agent.type === "pi"
+      ? extractPiStreamDisplayLines(line)
       : [line];
     if (tool) {
       toolCounts.set(tool, (toolCounts.get(tool) ?? 0) + 1);

--- a/ralph.ts
+++ b/ralph.ts
@@ -12,10 +12,10 @@ import { join } from "path";
 import {
   checkTerminalPromise,
   containsPromiseTag,
+  createPiStreamReducer,
   extractAgentCompletionText,
   extractClaudeStreamDisplayLines,
   extractCursorAgentStreamDisplayLines,
-  extractPiStreamDisplayLines,
   stripAnsi,
   tasksMarkdownAllComplete,
 } from "./completion";
@@ -2049,7 +2049,12 @@ async function streamProcessOutput(
     lastActivityTimeoutMs?: number;
     onActivityTimeout?: () => void;
   },
-): Promise<{ stdoutText: string; stderrText: string; toolCounts: Map<string, number> }> {
+): Promise<{
+  stdoutText: string;
+  stderrText: string;
+  question: string | null;
+  toolCounts: Map<string, number>;
+}> {
   const toolCounts = new Map<string, number>();
   let stdoutText = "";
   let stderrText = "";
@@ -2060,6 +2065,7 @@ async function streamProcessOutput(
 
   const compactTools = options.compactTools;
   const parseToolOutput = options.agent.parseToolOutput;
+  const piReducer = options.agent.type === "pi" ? createPiStreamReducer() : null;
 
   const maybePrintToolSummary = (force = false) => {
     if (!compactTools || toolCounts.size === 0) return;
@@ -2077,14 +2083,15 @@ async function streamProcessOutput(
 
   const handleLine = (line: string, isError: boolean) => {
     lastActivityAt = Date.now();
-    const tool = parseToolOutput(line);
-    const outputLines = options.agent.type === "claude-code" || options.agent.type === "qwen-code"
-      ? extractClaudeStreamDisplayLines(line)
-      : options.agent.type === "cursor-agent"
-      ? extractCursorAgentStreamDisplayLines(line)
-      : options.agent.type === "pi"
-      ? extractPiStreamDisplayLines(line)
-      : [line];
+    const piEffect = piReducer?.pushLine(line, isError);
+    const tool = piEffect ? piEffect.toolName : parseToolOutput(line);
+    const outputLines = piEffect?.displayLines ?? (
+      options.agent.type === "claude-code" || options.agent.type === "qwen-code"
+        ? extractClaudeStreamDisplayLines(line)
+        : options.agent.type === "cursor-agent"
+        ? extractCursorAgentStreamDisplayLines(line)
+        : [line]
+    );
     if (tool) {
       toolCounts.set(tool, (toolCounts.get(tool) ?? 0) + 1);
       if (compactTools && outputLines.length === 0) {
@@ -2187,14 +2194,14 @@ async function streamProcessOutput(
       streamText(
         proc.stdout,
         chunk => {
-          stdoutText += chunk;
+          if (!piReducer) stdoutText += chunk;
         },
         false,
       ),
       streamText(
         proc.stderr,
         chunk => {
-          stderrText += chunk;
+          if (!piReducer) stderrText += chunk;
         },
         true,
       ),
@@ -2207,7 +2214,18 @@ async function streamProcessOutput(
     maybePrintToolSummary(true);
   }
 
-  return { stdoutText, stderrText, toolCounts };
+  const piSummary = piReducer?.finish();
+  if (piSummary) {
+    stdoutText = piSummary.completionText;
+    stderrText = piSummary.diagnosticText;
+  }
+
+  return {
+    stdoutText,
+    stderrText,
+    question: piSummary?.question ?? null,
+    toolCounts,
+  };
 }
 // Main loop
 // Helper to detect per-iteration file changes using content hashes
@@ -2622,6 +2640,7 @@ async function runRalphLoop(): Promise<void> {
       const exitCodePromise = proc.exited;
       let result = "";
       let stderr = "";
+      let streamedQuestion: string | null = null;
       let toolCounts = new Map<string, number>();
 
       if (streamOutput) {
@@ -2649,6 +2668,7 @@ async function runRalphLoop(): Promise<void> {
         currentAbortController = null; // Clear after streaming completes
         result = streamed.stdoutText;
         stderr = streamed.stderrText;
+        streamedQuestion = streamed.question;
         toolCounts = streamed.toolCounts;
       } else {
         const stdoutPromise = new Response(proc.stdout).text();
@@ -2685,8 +2705,10 @@ async function runRalphLoop(): Promise<void> {
         });
       }
 
-      // For agents using stream-json, extract display text before checking completion
-      const completionCheckText = extractAgentCompletionText(result, agentConfig.type);
+      // Pi streaming has already reduced JSON events to assistant text; buffered Pi output is plain text.
+      const completionCheckText = agentConfig.type === "pi"
+        ? result
+        : extractAgentCompletionText(result, agentConfig.type);
       // Pi JSON includes user and tool events, so only extracted assistant text may signal a promise.
       const rawPromiseOutput = agentConfig.type === "pi" ? undefined : result;
 
@@ -2851,7 +2873,7 @@ async function runRalphLoop(): Promise<void> {
 
       // Check for question tool invocation and prompt user if needed
       if (handleQuestions) {
-        const detectedQuestion = detectQuestionTool(combinedOutput, agentConfig);
+        const detectedQuestion = streamedQuestion ?? detectQuestionTool(combinedOutput, agentConfig);
         if (detectedQuestion) {
           console.log(`\n🤔 Agent asked a question. Pausing to get your answer...`);
           const answer = await promptUser(detectedQuestion);

--- a/ralph.ts
+++ b/ralph.ts
@@ -2687,10 +2687,12 @@ async function runRalphLoop(): Promise<void> {
 
       // For agents using stream-json, extract display text before checking completion
       const completionCheckText = extractAgentCompletionText(result, agentConfig.type);
+      // Pi JSON includes user and tool events, so only extracted assistant text may signal a promise.
+      const rawPromiseOutput = agentConfig.type === "pi" ? undefined : result;
 
-      const completionSignalDetected = checkCompletion(completionCheckText, completionPromise, result);
-      const abortDetected = abortPromise ? checkCompletion(completionCheckText, abortPromise, result) : false;
-      let taskCompletionDetected = tasksMode ? checkCompletion(completionCheckText, taskPromise, result) : false;
+      const completionSignalDetected = checkCompletion(completionCheckText, completionPromise, rawPromiseOutput);
+      const abortDetected = abortPromise ? checkCompletion(completionCheckText, abortPromise, rawPromiseOutput) : false;
+      let taskCompletionDetected = tasksMode ? checkCompletion(completionCheckText, taskPromise, rawPromiseOutput) : false;
       const taskGateCompletion = taskCompletionDetected ? { satisfied: false } : taskCompletionSatisfiedByTaskGate(state);
       if (taskGateCompletion.satisfied) {
         taskCompletionDetected = true;

--- a/ralph.ts
+++ b/ralph.ts
@@ -38,7 +38,7 @@ const questionsPath = join(stateDir, "ralph-questions.json");
 let customConfigPath = "";
 let initConfigPath = "";
 
-const AGENT_TYPES = ["opencode", "claude-code", "codex", "copilot", "cursor-agent", "qwen-code"] as const;
+const AGENT_TYPES = ["opencode", "claude-code", "codex", "copilot", "cursor-agent", "qwen-code", "pi"] as const;
 type AgentType = (typeof AGENT_TYPES)[number];
 
 type AgentEnvOptions = { filterPlugins?: boolean; allowAllPermissions?: boolean };
@@ -183,6 +183,13 @@ const ARGS_TEMPLATES: Record<string, (prompt: string, model: string, options?: A
     if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
     return cmdArgs;
   },
+  "pi": (prompt, model, options) => {
+    const cmdArgs = ["-p", "--no-session"];
+    if (model) cmdArgs.push("--model", model);
+    if (options?.extraFlags?.length) cmdArgs.push(...options.extraFlags);
+    cmdArgs.push(prompt);
+    return cmdArgs;
+  },
   "default": (prompt, model, options) => {
     const cmdArgs: string[] = [];
     if (model) cmdArgs.push("--model", model);
@@ -252,6 +259,7 @@ function getDefaultConfig(): RalphConfig {
       { type: "copilot", command: "copilot", configName: "Copilot CLI", argsTemplate: "copilot", envTemplate: "default", parsePattern: "copilot" },
       { type: "cursor-agent", command: "cursor-agent", configName: "Cursor Agent", argsTemplate: "cursor-agent", envTemplate: "default", parsePattern: "cursor-agent" },
       { type: "qwen-code", command: "qwen", configName: "Qwen Code", argsTemplate: "qwen-code", envTemplate: "default", parsePattern: "qwen-code" },
+      { type: "pi", command: "pi", configName: "Pi", argsTemplate: "pi", envTemplate: "default", parsePattern: "default" },
     ],
   };
 }
@@ -325,6 +333,14 @@ const BUILT_IN_AGENTS: Record<AgentType, AgentConfig> = {
     parseToolOutput: PARSE_PATTERNS["qwen-code"],
     configName: "Qwen Code",
   },
+  pi: {
+    type: "pi",
+    command: resolveCommand("pi", process.env.RALPH_PI_BINARY),
+    buildArgs: ARGS_TEMPLATES["pi"],
+    buildEnv: ENV_TEMPLATES["default"],
+    parseToolOutput: PARSE_PATTERNS["default"],
+    configName: "Pi",
+  },
 };
 
 // Parse arguments early for --config and --init-config handling
@@ -376,7 +392,7 @@ Arguments:
   prompt              Task description for the AI to work on
 
 Options:
-  --agent AGENT       AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent, qwen-code
+  --agent AGENT       AI agent to use: opencode (default), claude-code, codex, copilot, cursor-agent, qwen-code, pi
   --codex-goal       Run Codex iterations in goal mode; final Codex/OMX prompt starts with /goal
   --codex-backend BACKEND  Backend for --codex-goal: codex or omx (default: detect; env RALPH_CODEX_BACKEND)
   --codex-goal-native  Force a native /goal attempt even when backend support is unconfirmed
@@ -390,7 +406,7 @@ Options:
   --model MODEL       Model to use (agent-specific, e.g., anthropic/claude-sonnet)
   --rotation LIST     Agent/model rotation for each iteration (comma-separated)
                       Each entry must be "agent:model" format
-                      Valid agents: opencode, claude-code, codex, copilot, cursor-agent, qwen-code
+                      Valid agents: opencode, claude-code, codex, copilot, cursor-agent, qwen-code, pi
                       Example: --rotation "opencode:claude-sonnet-4,claude-code:gpt-4o"
                       When used, --agent and --model are ignored
   --prompt-file, --file, -f  Read prompt content from a file
@@ -2337,6 +2353,9 @@ async function runRalphLoop(): Promise<void> {
   }
   if (disablePlugins && agentConfig.type === "qwen-code") {
     console.warn("Warning: --no-plugins has no effect with Qwen Code agent");
+  }
+  if (disablePlugins && agentConfig.type === "pi") {
+    console.warn("Warning: --no-plugins has no effect with Pi agent");
   }
 
   console.log(`

--- a/skills/open-ralph-wiggum/SKILL.md
+++ b/skills/open-ralph-wiggum/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use this skill whenever a user wants to run, install, configure, or understand open-ralph-wiggum (ralph).
   This skill can be used by any AI assistant or IDE agent (GitHub Copilot, Claude Code, Cursor, Windsurf, etc.).
   Triggers on: "ralph", "ralph wiggum", "agentic loop", "iterative AI loop", "autonomous coding loop",
-  "how to install ralph", "how to use ralph with Claude Code / Codex / Copilot / Cursor Agent / Qwen Code / OpenCode",
+  "how to install ralph", "how to use ralph with Claude Code / Codex / Copilot / Cursor Agent / Qwen Code / Pi / OpenCode",
   "ralph --agent", "ralph --tasks", "ralph --status", "--max-iterations", "--rotation",
   "how do I run ralph in VS Code / Cursor / JetBrains / Neovim",
   or any question about looping an AI coding agent until a task is done.
@@ -16,7 +16,7 @@ description: >
 
 **Open Ralph Wiggum** (`ralph`) wraps any supported AI coding agent in an autonomous loop: it sends the same prompt on every iteration, and the agent self-corrects by observing the state of the repo. The loop ends when the agent outputs a configurable completion promise (e.g. `<promise>COMPLETE</promise>`).
 
-Supported agents: **Claude Code**, **OpenAI Codex**, **GitHub Copilot CLI**, **Cursor Agent**, **Qwen Code**, **OpenCode** (default).
+Supported agents: **Claude Code**, **OpenAI Codex**, **GitHub Copilot CLI**, **Cursor Agent**, **Qwen Code**, **Pi**, **OpenCode** (default).
 
 ---
 
@@ -31,6 +31,7 @@ Supported agents: **Claude Code**, **OpenAI Codex**, **GitHub Copilot CLI**, **C
   - `copilot` — [GitHub Copilot CLI](https://github.com/github/copilot-cli)
   - `cursor-agent` — [Cursor Agent CLI](https://cursor.com/cli/)
   - `qwen` — [Qwen Code CLI](https://github.com/QwenLM/qwen-code)
+  - `pi` — [Pi](https://pi.dev)
   - `opencode` — [OpenCode](https://opencode.ai)
 
 ### npm (recommended)
@@ -117,6 +118,15 @@ ralph "Refactor the database layer. Output <promise>COMPLETE</promise> when done
 
 Requires Qwen Code installed via `npm install -g @qwen-code/qwen-code`.
 
+### Pi
+
+```bash
+ralph "Fix the failing tests. Output <promise>COMPLETE</promise> when done." \
+  --agent pi --max-iterations 15
+```
+
+Requires Pi installed via `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`.
+
 ---
 
 ## Checking Available Agents and Models
@@ -174,10 +184,18 @@ qwen --version
 npm install -g @qwen-code/qwen-code
 ```
 
+**Pi** — check version and install if needed:
+
+```bash
+pi --version
+# If not installed:
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
 ### Quick environment check (Linux/macOS)
 
 ```bash
-for bin in opencode claude codex copilot cursor-agent qwen; do
+for bin in opencode claude codex copilot cursor-agent qwen pi; do
   if command -v "$bin" &>/dev/null; then echo "✅ $bin: $(which $bin)"; else echo "❌ $bin: not found"; fi
 done && \
   [[ -n "$GH_TOKEN" ]] && echo "✅ GH_TOKEN set (Copilot CLI)" || echo "ℹ️  GH_TOKEN not set (needed only for Copilot CLI)"
@@ -195,6 +213,7 @@ done && \
 | Copilot CLI        | `--agent copilot`       | `copilot`      | `RALPH_COPILOT_BINARY`        |
 | Cursor Agent       | `--agent cursor-agent`  | `cursor-agent` | `RALPH_CURSOR_AGENT_BINARY`   |
 | Qwen Code          | `--agent qwen-code`     | `qwen`         | `RALPH_QWEN_CODE_BINARY`      |
+| Pi                 | `--agent pi`            | `pi`           | `RALPH_PI_BINARY`             |
 
 Use environment variables to point to a custom binary path if the CLI is not on `$PATH`.
 
@@ -203,7 +222,7 @@ Use environment variables to point to a custom binary path if the CLI is not on 
 ## Key Options
 
 ```
---agent AGENT            Agent to use (opencode|claude-code|codex|copilot|cursor-agent|qwen-code)
+--agent AGENT            Agent to use (opencode|claude-code|codex|copilot|cursor-agent|qwen-code|pi)
 --model MODEL            Model name (agent-specific, e.g. claude-sonnet-4, gpt-5-codex)
 --max-iterations N       Stop after N iterations (always set this as a safety net)
 --min-iterations N       Require at least N iterations before allowing completion (default: 1)
@@ -500,7 +519,7 @@ ralph "Refactor the auth module" \
   --max-iterations 15
 ```
 
-Valid agents are `opencode`, `claude-code`, `codex`, `copilot`, `cursor-agent`, and `qwen-code`.
+Valid agents are `opencode`, `claude-code`, `codex`, `copilot`, `cursor-agent`, `qwen-code`, and `pi`.
 
 Format: `agent:model` entries separated by commas. When `--rotation` is set, `--agent` and `--model` are ignored. The list cycles (iteration 3 of a 2-entry rotation goes back to entry 1).
 
@@ -591,6 +610,32 @@ Notes:
 - `--no-plugins` has no effect with Qwen Code
 - Headless mode uses `--output-format stream-json --include-partial-messages`
 - Binary is `qwen`; override with `RALPH_QWEN_CODE_BINARY`
+
+### Pi
+
+Install:
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+Usage:
+
+```bash
+ralph "Fix the failing tests" \
+  --agent pi --max-iterations 10
+
+ralph "Refactor the auth module" \
+  --agent pi --model anthropic/claude-sonnet-4-5 --max-iterations 15
+```
+
+Notes:
+
+- Ralph runs each Pi iteration with `pi -p --no-session`
+- Binary is `pi`; override with `RALPH_PI_BINARY`
+- Pass Pi-specific flags after `--`, for example `-- --approve`
+- Pi has no built-in permission prompts, so `--allow-all` and `--no-allow-all` add no Pi flags
+- `--no-plugins` has no effect with Pi
 
 ### Cursor Agent
 

--- a/skills/open-ralph-wiggum/SKILL.md
+++ b/skills/open-ralph-wiggum/SKILL.md
@@ -631,7 +631,7 @@ ralph "Refactor the auth module" \
 
 Notes:
 
-- Ralph runs each Pi iteration with `pi -p --no-session`
+- Ralph runs each Pi iteration with `pi -p --no-session`; streaming mode adds `--mode json` for assistant output and tool summaries
 - Binary is `pi`; override with `RALPH_PI_BINARY`
 - Pass Pi-specific flags after `--`, for example `-- --approve`
 - Pi has no built-in permission prompts, so `--allow-all` and `--no-allow-all` add no Pi flags

--- a/skills/open-ralph-wiggum/SKILL.md
+++ b/skills/open-ralph-wiggum/SKILL.md
@@ -5,7 +5,7 @@ description: >
   This skill can be used by any AI assistant or IDE agent (GitHub Copilot, Claude Code, Cursor, Windsurf, etc.).
   Triggers on: "ralph", "ralph wiggum", "agentic loop", "iterative AI loop", "autonomous coding loop",
   "how to install ralph", "how to use ralph with Claude Code / Codex / Copilot / Cursor Agent / Qwen Code / Pi / OpenCode",
-  "ralph --agent", "ralph --tasks", "ralph --status", "--max-iterations", "--rotation",
+  "ralph --agent", "ralph --tasks", "ralph --status", "ralph --steer", "--max-iterations", "--rotation",
   "how do I run ralph in VS Code / Cursor / JetBrains / Neovim",
   or any question about looping an AI coding agent until a task is done.
   Even if the user doesn't say "ralph" explicitly — if they want to run an AI agent in a loop
@@ -125,7 +125,7 @@ ralph "Fix the failing tests. Output <promise>COMPLETE</promise> when done." \
   --agent pi --max-iterations 15
 ```
 
-Requires Pi installed via `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`.
+Requires Pi installed via `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`. Current-iteration steering also requires RPC mode and `agent_settled` support.
 
 ---
 
@@ -236,6 +236,7 @@ Use environment variables to point to a custom binary path if the CLI is not on 
 --allow-all              Auto-approve all tool permission prompts (default: on)
 --status                 Show live loop status from another terminal
 --add-context TEXT       Inject a hint for the next iteration without stopping the loop
+--steer TEXT            Steer the current Pi iteration at its next safe turn boundary
 --clear-context          Remove pending context
 --list-tasks             List current tasks (Tasks Mode)
 --add-task TEXT          Add a task (Tasks Mode)
@@ -430,11 +431,14 @@ From a second terminal in the same project directory:
 
 ```bash
 ralph --status      # Shows iteration progress, history, struggle indicators
-ralph --add-context "The bug is in utils/parser.ts line 42"  # Guide the agent
+ralph --add-context "The bug is in utils/parser.ts line 42"  # Next iteration
+ralph --steer "Inspect the parser failure first"  # Current Pi iteration only
 ralph --clear-context  # Remove queued hint
 ```
 
 The status dashboard shows iteration count, time elapsed, tool usage per iteration, and struggle warnings (e.g., no file changes in N iterations).
+
+`--add-context` writes guidance for the next iteration and works with every agent. `--steer` sends guidance to the currently running Pi process; Pi consumes it after current tool calls and before the next model call. Steering fails explicitly for non-Pi agents, inactive/ended iterations, or ambiguous concurrent loops, and never falls back to context.
 
 The `--status` output includes:
 

--- a/tests/agent-iteration.test.ts
+++ b/tests/agent-iteration.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { startAgentIteration } from "../agent-iteration";
+
+describe("AgentIteration", () => {
+  it("runs a fresh Pi RPC process and delivers steering through stdin", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-agent-iteration."));
+    const fakePi = join(workdir, "pi");
+    const capturedArgs = join(workdir, "pi-args.json");
+    const capturedCommands = join(workdir, "pi-commands.jsonl");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+printf '%s\\n' "$@" > "${capturedArgs}"
+while IFS= read -r command; do
+  printf '%s\\n' "$command" >> "${capturedCommands}"
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo '{"type":"tool_execution_start","toolCallId":"call_1","toolName":"read","args":{}}'
+  elif [[ "$command" == *'"type":"steer"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    echo '{"type":"queue_update","steering":["Focus on the failing test"],"followUp":[]}'
+    printf '{"type":"response","id":"%s","command":"steer","success":true}\\n' "$id"
+    sleep 0.05
+    echo '{"type":"queue_update","steering":[],"followUp":[]}'
+    echo '{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Focus on the failing test"}]}}'
+    echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    echo '{"type":"agent_end","messages":[],"willRetry":false}'
+    echo '{"type":"agent_settled"}'
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const iteration = startAgentIteration({
+        agent: {
+          type: "pi",
+          command: fakePi,
+          parseToolOutput: () => null,
+        },
+        args: ["--mode", "rpc", "--no-session", "--model", "test/model", "--approve"],
+        cwd: workdir,
+        env: { ...process.env },
+        prompt: "Initial task prompt",
+        streamOutput: true,
+        compactTools: true,
+        iterationStart: Date.now(),
+        lastActivityTimeoutMs: 0,
+      });
+
+      expect(iteration.steer).toBeFunction();
+      await iteration.steer?.("Focus on the failing test");
+      const result = await iteration.settled;
+
+      expect(readFileSync(capturedArgs, "utf-8").trim().split("\n")).toEqual([
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--model",
+        "test/model",
+        "--approve",
+      ]);
+
+      const commands = readFileSync(capturedCommands, "utf-8")
+        .trim()
+        .split("\n")
+        .map(line => JSON.parse(line));
+      expect(commands.map(command => command.type)).toEqual(["prompt", "steer"]);
+      expect(commands[0].message).toBe("Initial task prompt");
+      expect(commands[1].message).toBe("Focus on the failing test");
+      expect(result.completionText).toBe("<promise>COMPLETE</promise>");
+      expect(result.toolCounts).toEqual(new Map([["read", 1]]));
+      expect(result.exitCode).toBe(0);
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks Pi exit without agent_settled as an incomplete termination", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-no-settle."));
+    const fakePi = join(workdir, "pi");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+while IFS= read -r command; do
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    exit 0
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const iteration = startAgentIteration({
+        agent: { type: "pi", command: fakePi, parseToolOutput: () => null },
+        args: ["--mode", "rpc", "--no-session"],
+        cwd: workdir,
+        env: { ...process.env },
+        prompt: "Initial task prompt",
+        streamOutput: true,
+        compactTools: true,
+        iterationStart: Date.now(),
+        lastActivityTimeoutMs: 0,
+      });
+
+      const result = await iteration.settled;
+      expect(result.termination).toBe("process-exit");
+      expect(result.completionText).toContain("<promise>COMPLETE</promise>");
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed Pi RPC records", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-malformed."));
+    const fakePi = join(workdir, "pi");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+while IFS= read -r command; do
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo 'not-json'
+    sleep 5
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const iteration = startAgentIteration({
+        agent: { type: "pi", command: fakePi, parseToolOutput: () => null },
+        args: ["--mode", "rpc", "--no-session"],
+        cwd: workdir,
+        env: { ...process.env },
+        prompt: "Initial task prompt",
+        streamOutput: true,
+        compactTools: true,
+        iterationStart: Date.now(),
+        lastActivityTimeoutMs: 0,
+      });
+
+      await expect(iteration.settled).rejects.toThrow("Invalid Pi RPC record");
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails steering when Pi settles before consuming the queue", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-settle-race."));
+    const fakePi = join(workdir, "pi");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+while IFS= read -r command; do
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+  elif [[ "$command" == *'"type":"steer"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    echo '{"type":"queue_update","steering":["Too late"],"followUp":[]}'
+    printf '{"type":"response","id":"%s","command":"steer","success":true}\\n' "$id"
+    echo '{"type":"agent_settled"}'
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const iteration = startAgentIteration({
+        agent: { type: "pi", command: fakePi, parseToolOutput: () => null },
+        args: ["--mode", "rpc", "--no-session"],
+        cwd: workdir,
+        env: { ...process.env },
+        prompt: "Initial task prompt",
+        streamOutput: true,
+        compactTools: true,
+        iterationStart: Date.now(),
+        lastActivityTimeoutMs: 0,
+      });
+
+      const steering = iteration.steer?.("Too late");
+      expect(steering).toBeDefined();
+      await expect(steering!).rejects.toThrow("ended before the request was delivered");
+      expect((await iteration.settled).exitCode).toBe(0);
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects pending steering when the Pi protocol fails", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-steer-protocol-error."));
+    const fakePi = join(workdir, "pi");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+while IFS= read -r command; do
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+  elif [[ "$command" == *'"type":"steer"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    echo '{"type":"queue_update","steering":["Break the protocol"],"followUp":[]}'
+    printf '{"type":"response","id":"%s","command":"steer","success":true}\\n' "$id"
+    echo 'not-json'
+    sleep 5
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const iteration = startAgentIteration({
+        agent: { type: "pi", command: fakePi, parseToolOutput: () => null },
+        args: ["--mode", "rpc", "--no-session"],
+        cwd: workdir,
+        env: { ...process.env },
+        prompt: "Initial task prompt",
+        streamOutput: true,
+        compactTools: true,
+        iterationStart: Date.now(),
+        lastActivityTimeoutMs: 0,
+      });
+
+      const steering = iteration.steer!("Break the protocol");
+      await expect(iteration.settled).rejects.toThrow("Invalid Pi RPC record");
+      const steeringOutcome = await Promise.race([
+        steering.then(() => "resolved", () => "rejected"),
+        new Promise<string>(resolve => setTimeout(() => resolve("timeout"), 500)),
+      ]);
+      expect(steeringOutcome).toBe("rejected");
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("cancels blocking extension UI requests in headless RPC mode", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-extension-ui."));
+    const fakePi = join(workdir, "pi");
+    const capturedCommands = join(workdir, "pi-commands.jsonl");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+while IFS= read -r command; do
+  printf '%s\\n' "$command" >> "${capturedCommands}"
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo '{"type":"extension_ui_request","id":"ui-1","method":"confirm","title":"Continue","message":"Continue?"}'
+  elif [[ "$command" == *'"type":"extension_ui_response"'* ]]; then
+    echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}'
+    echo '{"type":"agent_settled"}'
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const iteration = startAgentIteration({
+        agent: { type: "pi", command: fakePi, parseToolOutput: () => null },
+        args: ["--mode", "rpc", "--no-session"],
+        cwd: workdir,
+        env: { ...process.env },
+        prompt: "Initial task prompt",
+        streamOutput: true,
+        compactTools: true,
+        iterationStart: Date.now(),
+        lastActivityTimeoutMs: 0,
+      });
+
+      expect((await iteration.settled).completionText).toBe("done");
+      const commands = readFileSync(capturedCommands, "utf-8")
+        .trim()
+        .split("\n")
+        .map(line => JSON.parse(line));
+      expect(commands.map(command => command.type)).toEqual(["prompt", "extension_ui_response"]);
+      expect(commands[1]).toMatchObject({ id: "ui-1", cancelled: true });
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves streamed output and tool telemetry for ordinary agents", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-spawn-iteration."));
+    const fakeAgent = join(workdir, "agent");
+
+    try {
+      writeFileSync(fakeAgent, `#!/usr/bin/env bash
+echo '|  read'
+echo '<promise>COMPLETE</promise>'
+`);
+      chmodSync(fakeAgent, 0o755);
+
+      const iteration = startAgentIteration({
+        agent: {
+          type: "opencode",
+          command: fakeAgent,
+          parseToolOutput: line => line.match(/^\|\s{2}([A-Za-z0-9_-]+)/)?.[1] ?? null,
+        },
+        args: ["run", "Initial task prompt"],
+        cwd: workdir,
+        env: { ...process.env },
+        prompt: "Initial task prompt",
+        streamOutput: true,
+        compactTools: true,
+        iterationStart: Date.now(),
+        lastActivityTimeoutMs: 0,
+      });
+
+      expect(iteration.steer).toBeUndefined();
+      const result = await iteration.settled;
+      expect(result.completionText).toContain("|  read\n<promise>COMPLETE</promise>");
+      expect(result.rawPromiseText).toContain("<promise>COMPLETE</promise>");
+      expect(result.toolCounts).toEqual(new Map([["read", 1]]));
+      expect(result.exitCode).toBe(0);
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/loop-control.test.ts
+++ b/tests/loop-control.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  LoopControlError,
+  startLoopControl,
+  steerCurrentIteration,
+} from "../loop-control";
+
+const runtimeDirs: string[] = [];
+
+afterEach(() => {
+  delete process.env.RALPH_CONTROL_DIR;
+  for (const dir of runtimeDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function useIsolatedRuntime(): string {
+  const runtimeDir = mkdtempSync(join(tmpdir(), "ralph-control-test."));
+  runtimeDirs.push(runtimeDir);
+  process.env.RALPH_CONTROL_DIR = runtimeDir;
+  return runtimeDir;
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (check()) return;
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  throw new Error("Timed out waiting for control fixture");
+}
+
+describe("LoopControl", () => {
+  it("routes steering to the active workspace generation", async () => {
+    useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-workspace."));
+    runtimeDirs.push(workspace);
+    const control = await startLoopControl(workspace);
+    let received = "";
+
+    try {
+      const deactivate = control.activate("pi", async text => {
+        received = text;
+      });
+
+      await steerCurrentIteration(workspace, "Focus on the failing test");
+      expect(received).toBe("Focus on the failing test");
+
+      deactivate();
+      await expect(steerCurrentIteration(workspace, "Too late")).rejects.toMatchObject({
+        code: "no-active-iteration",
+      });
+    } finally {
+      await control.close();
+    }
+  });
+
+  it("waits beyond the request framing deadline for a safe turn boundary", async () => {
+    useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-long-tool."));
+    runtimeDirs.push(workspace);
+    const control = await startLoopControl(workspace);
+
+    try {
+      control.activate("pi", async () => {
+        await new Promise(resolve => setTimeout(resolve, 2_200));
+      });
+      const startedAt = Date.now();
+      await steerCurrentIteration(workspace, "Wait for the long tool");
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(2_100);
+    } finally {
+      await control.close();
+    }
+  });
+
+  it("does not let an old lease deactivate a newer generation", async () => {
+    useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-generation."));
+    runtimeDirs.push(workspace);
+    const control = await startLoopControl(workspace);
+    let deliveredTo = "";
+
+    try {
+      const releaseOld = control.activate("pi", async () => { deliveredTo = "old"; });
+      control.activate("pi", async () => { deliveredTo = "new"; });
+      releaseOld();
+
+      await steerCurrentIteration(workspace, "Use the current generation");
+      expect(deliveredTo).toBe("new");
+    } finally {
+      await control.close();
+    }
+  });
+
+  it("reports unsupported agents without falling back to context", async () => {
+    useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-unsupported."));
+    runtimeDirs.push(workspace);
+    const control = await startLoopControl(workspace);
+
+    try {
+      control.activate("codex");
+      const error = await steerCurrentIteration(workspace, "Do this now").catch(value => value);
+      expect(error).toBeInstanceOf(LoopControlError);
+      expect(error).toMatchObject({ code: "unsupported-agent" });
+      expect(error.message).toContain("codex");
+      expect(error.message).toContain("--add-context");
+    } finally {
+      await control.close();
+    }
+  });
+
+  it("rejects oversized steering before discovery", async () => {
+    useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-size."));
+    runtimeDirs.push(workspace);
+
+    await expect(steerCurrentIteration(workspace, "x".repeat(64 * 1024 + 1))).rejects.toMatchObject({
+      code: "message-too-large",
+    });
+  });
+
+  it("accepts escaped JSON text within the steering byte limit", async () => {
+    useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-escaped-size."));
+    runtimeDirs.push(workspace);
+    const control = await startLoopControl(workspace);
+    const text = "\\".repeat(40_000);
+    let received = "";
+
+    try {
+      control.activate("pi", async value => { received = value; });
+      await steerCurrentIteration(workspace, text);
+      expect(received).toBe(text);
+    } finally {
+      await control.close();
+    }
+  });
+
+  it("removes stale descriptor and socket artifacts after a crashed loop", async () => {
+    const runtimeDir = useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-stale."));
+    runtimeDirs.push(workspace);
+    const fixture = join(workspace, "control-fixture.ts");
+    const ready = join(workspace, "ready");
+    const modulePath = join(import.meta.dir, "..", "loop-control.ts");
+    writeFileSync(fixture, `
+import { startLoopControl } from ${JSON.stringify(modulePath)};
+import { writeFileSync } from "fs";
+const control = await startLoopControl(${JSON.stringify(workspace)});
+control.activate("pi", async () => {});
+writeFileSync(${JSON.stringify(ready)}, "ready");
+await new Promise(() => {});
+`);
+
+    const child = Bun.spawn({
+      cmd: ["bun", fixture],
+      env: { ...process.env, RALPH_CONTROL_DIR: runtimeDir },
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    try {
+      await waitFor(() => existsSync(ready));
+      const descriptorName = readdirSync(runtimeDir).find(name => name.endsWith(".json"));
+      expect(descriptorName).toBeDefined();
+      const descriptorPath = join(runtimeDir, descriptorName!);
+      const endpoint = JSON.parse(readFileSync(descriptorPath, "utf-8")).endpoint as string;
+
+      child.kill("SIGKILL");
+      await child.exited;
+      expect(existsSync(descriptorPath)).toBe(true);
+
+      await expect(steerCurrentIteration(workspace, "Cannot be delivered")).rejects.toMatchObject({
+        code: "no-active-loop",
+      });
+      expect(readdirSync(runtimeDir)).toEqual([]);
+      if (process.platform !== "win32") expect(existsSync(endpoint)).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill("SIGKILL");
+      await child.exited;
+    }
+  });
+
+  it("fails closed when multiple loops own the same workspace", async () => {
+    useIsolatedRuntime();
+    const workspace = mkdtempSync(join(tmpdir(), "ralph-control-ambiguous."));
+    runtimeDirs.push(workspace);
+    const first = await startLoopControl(workspace);
+    const second = await startLoopControl(workspace);
+    let deliveries = 0;
+
+    try {
+      first.activate("pi", async () => { deliveries++; });
+      second.activate("pi", async () => { deliveries++; });
+
+      await expect(steerCurrentIteration(workspace, "Do not guess")).rejects.toMatchObject({
+        code: "ambiguous-loop",
+      });
+      expect(deliveries).toBe(0);
+    } finally {
+      await Promise.all([first.close(), second.close()]);
+    }
+  });
+});

--- a/tests/pi-steering-cli.test.ts
+++ b/tests/pi-steering-cli.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(check: () => boolean, timeoutMs: number, message: string): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (check()) return;
+    await wait(25);
+  }
+  throw new Error(message);
+}
+
+async function readStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return "";
+  return new Response(stream).text();
+}
+
+describe("ralph --steer", () => {
+  it("delivers text to the current Pi turn and waits for consumption", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-steer-cli."));
+    const controlDir = mkdtempSync(join(tmpdir(), "ralph-steer-control."));
+    const fakePi = join(workdir, "pi");
+    const readyFile = join(workdir, "pi-ready");
+    const commandsFile = join(workdir, "pi-commands.jsonl");
+    const rootDir = join(import.meta.dir, "..");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+while IFS= read -r command; do
+  printf '%s\\n' "$command" >> "${commandsFile}"
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo '{"type":"tool_execution_start","toolCallId":"call_1","toolName":"read","args":{}}'
+    touch "${readyFile}"
+  elif [[ "$command" == *'"type":"steer"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    echo '{"type":"queue_update","steering":["Focus on the failing test"],"followUp":[]}'
+    printf '{"type":"response","id":"%s","command":"steer","success":true}\\n' "$id"
+    sleep 0.1
+    echo '{"type":"queue_update","steering":[],"followUp":[]}'
+    echo '{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Focus on the failing test"}]}}'
+    echo '{"type":"tool_execution_end","toolCallId":"call_1","toolName":"read","result":{},"isError":false}'
+    echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    echo '{"type":"agent_end","messages":[],"willRetry":false}'
+    echo '{"type":"agent_settled"}'
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const env = {
+        ...process.env,
+        RALPH_PI_BINARY: fakePi,
+        RALPH_CONTROL_DIR: controlDir,
+      };
+      const loop = Bun.spawn({
+        cmd: [
+          "bun",
+          join(rootDir, "ralph.ts"),
+          "Complete the task when steered.",
+          "--agent", "pi",
+          "--max-iterations", "1",
+          "--no-commit",
+          "--no-questions",
+          "--no-allow-all",
+        ],
+        cwd: workdir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const loopStdout = readStream(loop.stdout);
+      const loopStderr = readStream(loop.stderr);
+
+      try {
+        await waitFor(() => existsSync(readyFile), 5_000, "fake Pi did not receive the initial prompt");
+        await wait(50);
+
+        const steer = Bun.spawn({
+          cmd: ["bun", join(rootDir, "ralph.ts"), "--steer", "Focus on the failing test"],
+          cwd: workdir,
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [steerStdout, steerStderr, steerExitCode] = await Promise.all([
+          readStream(steer.stdout),
+          readStream(steer.stderr),
+          steer.exited,
+        ]);
+
+        expect(steerExitCode).toBe(0);
+        expect(steerStderr).toBe("");
+        expect(steerStdout).toContain("Steering delivered to the active Pi iteration");
+
+        const [stdout, stderr, exitCode] = await Promise.all([
+          loopStdout,
+          loopStderr,
+          loop.exited,
+        ]);
+        expect(exitCode).toBe(0);
+        expect(stderr).toBe("");
+        expect(stdout).toContain("Completion promise detected");
+        expect(stdout).not.toContain("Focus on the failing test");
+
+        const commands = readFileSync(commandsFile, "utf-8")
+          .trim()
+          .split("\n")
+          .map(line => JSON.parse(line));
+        expect(commands.map(command => command.type)).toEqual(["prompt", "steer"]);
+        expect(commands[1].message).toBe("Focus on the failing test");
+      } finally {
+        if (loop.exitCode === null) loop.kill("SIGTERM");
+        await loop.exited;
+        await Promise.all([loopStdout, loopStderr]);
+      }
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+      rmSync(controlDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-Pi iterations without writing next-iteration context", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-steer-unsupported."));
+    const controlDir = mkdtempSync(join(tmpdir(), "ralph-steer-unsupported-control."));
+    const fakeAgent = join(workdir, "opencode");
+    const readyFile = join(workdir, "agent-ready");
+    const contextFile = join(workdir, ".ralph", "ralph-context.md");
+    const rootDir = join(import.meta.dir, "..");
+
+    try {
+      writeFileSync(fakeAgent, `#!/usr/bin/env bun
+import { writeFileSync } from "fs";
+writeFileSync("${readyFile}", "ready");
+console.log("ordinary agent ready");
+await new Promise(() => {});
+`);
+      chmodSync(fakeAgent, 0o755);
+
+      const env = {
+        ...process.env,
+        RALPH_OPENCODE_BINARY: fakeAgent,
+        RALPH_CONTROL_DIR: controlDir,
+      };
+      const loop = Bun.spawn({
+        cmd: [
+          "bun",
+          join(rootDir, "ralph.ts"),
+          "Wait for steering.",
+          "--max-iterations", "1",
+          "--no-commit",
+          "--no-questions",
+          "--no-allow-all",
+        ],
+        cwd: workdir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const loopStdout = readStream(loop.stdout);
+      const loopStderr = readStream(loop.stderr);
+
+      try {
+        await waitFor(() => existsSync(readyFile), 5_000, "ordinary agent did not start");
+        await wait(50);
+
+        const steer = Bun.spawn({
+          cmd: ["bun", join(rootDir, "ralph.ts"), "--steer", "Do this now"],
+          cwd: workdir,
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [steerStdout, steerStderr, steerExitCode] = await Promise.all([
+          readStream(steer.stdout),
+          readStream(steer.stderr),
+          steer.exited,
+        ]);
+
+        expect(steerExitCode).toBe(1);
+        expect(steerStdout).toBe("");
+        expect(steerStderr).toContain('Current agent "opencode"');
+        expect(steerStderr).toContain("--add-context");
+        expect(existsSync(contextFile)).toBe(false);
+      } finally {
+        if (loop.exitCode === null) loop.kill("SIGINT");
+        await loop.exited;
+        await Promise.all([loopStdout, loopStderr]);
+      }
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+      rmSync(controlDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import {
   checkTerminalPromise,
   containsPromiseTag,
+  createPiStreamReducer,
   extractAgentCompletionText,
   extractClaudeStreamDisplayLines,
   extractCursorAgentStreamDisplayLines,
@@ -224,6 +225,147 @@ describe("agent stream output extraction", () => {
     expect(checkTerminalPromise(extractAgentCompletionText(output, "pi"), "COMPLETE")).toBe(true);
   });
 
+  it("reduces cumulative Pi events without retaining their raw payloads", () => {
+    const reducer = createPiStreamReducer();
+    const repeatedPayload = "x".repeat(32 * 1024);
+
+    for (let index = 0; index < 128; index++) {
+      reducer.pushLine(JSON.stringify({
+        type: "message_update",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: `${index}:${repeatedPayload}` }],
+        },
+      }), false);
+    }
+
+    const toolEffect = reducer.pushLine(JSON.stringify({
+      type: "tool_execution_start",
+      toolCallId: "call_1",
+      toolName: "edit",
+      args: {},
+    }), false);
+    reducer.pushLine(JSON.stringify({
+      type: "tool_execution_end",
+      toolCallId: "call_1",
+      toolName: "edit",
+      result: { content: [{ type: "text", text: repeatedPayload }] },
+      isError: false,
+    }), false);
+    reducer.pushLine(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "<promise>COMPLETE</promise>" }],
+      },
+    }), false);
+    reducer.pushLine(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "done\n<promise>COMPLETE</promise>" }],
+      },
+    }), false);
+
+    const summary = reducer.finish();
+    expect(toolEffect.toolName).toBe("edit");
+    expect(summary.completionText).toBe("done\n<promise>COMPLETE</promise>");
+    expect(summary.completionText.length + summary.diagnosticText.length).toBeLessThan(1024);
+  });
+
+  it("ignores every promise from non-assistant Pi events", () => {
+    const reducer = createPiStreamReducer();
+    const falsePromises = [
+      "<promise>COMPLETE</promise>",
+      "<promise>ABORT</promise>",
+      "<promise>READY_FOR_NEXT_TASK</promise>",
+    ].join("\n");
+
+    for (const event of [
+      { type: "message_update", message: { role: "assistant", content: falsePromises } },
+      { type: "tool_execution_end", result: { content: falsePromises }, isError: false },
+      { type: "message_end", message: { role: "user", content: falsePromises } },
+      { type: "message_end", message: { role: "toolResult", content: falsePromises } },
+      { type: "agent_end", messages: [{ role: "assistant", content: falsePromises }] },
+    ]) {
+      reducer.pushLine(JSON.stringify(event), false);
+    }
+    reducer.pushLine(
+      `{"type":"message_end","message":{"role":"user","content":${JSON.stringify(falsePromises)}`,
+      false,
+    );
+
+    expect(reducer.finish().completionText).toBe("");
+  });
+
+  it("discards irrelevant Pi events without parsing their payloads", () => {
+    const reducer = createPiStreamReducer();
+    const effect = reducer.pushLine(
+      `{"type":"message_update","message":"${"x".repeat(128 * 1024)}`,
+      false,
+    );
+
+    expect(effect.displayLines).toEqual([]);
+    expect(reducer.finish().completionText).toBe("");
+  });
+
+  it("retains Pi stdout errors for bounded diagnostics", () => {
+    const reducer = createPiStreamReducer();
+
+    reducer.pushLine(JSON.stringify({
+      type: "error",
+      error: { message: "ProviderModelNotFoundError: missing model" },
+    }), false);
+    reducer.pushLine(JSON.stringify({
+      type: "tool_execution_end",
+      toolCallId: "call_failed",
+      toolName: "bash",
+      isError: true,
+      result: { content: [{ type: "text", text: "error: command failed" }] },
+    }), false);
+
+    const summary = reducer.finish();
+    expect(summary.diagnosticText).toContain("ProviderModelNotFoundError: missing model");
+    expect(summary.diagnosticText).toContain("error: command failed");
+  });
+
+  it("bounds Pi diagnostics and retains the question signal", () => {
+    const reducer = createPiStreamReducer();
+    const diagnosticTail = ":diagnostic-tail";
+
+    reducer.pushLine(`error:${"x".repeat(128 * 1024)}${diagnosticTail}`, true);
+    reducer.pushLine(JSON.stringify({
+      type: "tool_execution_start",
+      toolCallId: "call_question",
+      toolName: "question",
+      args: { question: "Should I continue?" },
+    }), false);
+
+    const summary = reducer.finish();
+    expect(summary.diagnosticText.length).toBe(64 * 1024);
+    expect(summary.diagnosticText).toEndWith(diagnosticTail);
+    expect(summary.question).toBe("Should I continue?");
+  });
+
+  it("keeps only a bounded tail of the final Pi assistant text", () => {
+    const reducer = createPiStreamReducer();
+    reducer.pushLine(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{
+          type: "text",
+          text: `${"女".repeat(128 * 1024)}\n<promise>COMPLETE</promise>`,
+        }],
+      },
+    }), false);
+
+    const summary = reducer.finish();
+    expect(new TextEncoder().encode(summary.completionText).byteLength).toBeLessThanOrEqual(64 * 1024);
+    expect(summary.completionText).not.toContain("\uFFFD");
+    expect(checkTerminalPromise(summary.completionText, "COMPLETE")).toBe(true);
+  });
+
   it("leaves non-streaming agents unchanged for completion detection", () => {
     const output = "Finished\n<promise>COMPLETE</promise>";
     expect(extractAgentCompletionText(output, "opencode")).toBe(output);
@@ -332,6 +474,49 @@ echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"te
       expect(readFileSync(join(workdir, ".ralph", "ralph-tasks.md"), "utf-8")).toContain(
         "- [x] Verify Pi task mode",
       );
+    } finally {
+      if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects model errors from Pi stdout events", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-model-error-test."));
+    const fakePi = join(workdir, "pi");
+    const rootDir = join(import.meta.dir, "..");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+echo '{"type":"error","error":{"message":"ProviderModelNotFoundError: missing model"}}'
+exit 1
+`);
+      chmodSync(fakePi, 0o755);
+
+      const proc = Bun.spawn({
+        cmd: [
+          "bun",
+          join(rootDir, "ralph.ts"),
+          "Run the task.",
+          "--agent", "pi",
+          "--max-iterations", "1",
+          "--no-commit",
+          "--no-questions",
+          "--no-allow-all",
+        ],
+        cwd: workdir,
+        env: { ...process.env, RALPH_PI_BINARY: fakePi },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("Model configuration error detected");
+      expect(stderr).toContain("could not find a valid model");
     } finally {
       if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
     }

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -252,9 +252,16 @@ describe("Pi agent invocation", () => {
     try {
       writeFileSync(fakePi, `#!/usr/bin/env bash
 printf '%s\\n' "$@" > "${capturedArgs}"
+cat > .ralph/ralph-tasks.md <<'TASKS'
+# Ralph Tasks
+
+- [x] Verify Pi task mode
+TASKS
 echo '<promise>COMPLETE</promise>'
 `);
       chmodSync(fakePi, 0o755);
+      await Bun.$`mkdir -p ${join(workdir, ".ralph")}`;
+      writeFileSync(join(workdir, ".ralph", "ralph-tasks.md"), "# Ralph Tasks\n\n- [ ] Verify Pi task mode\n");
 
       const proc = Bun.spawn({
         cmd: [
@@ -264,6 +271,7 @@ echo '<promise>COMPLETE</promise>'
           "--agent", "pi",
           "--model", "google/gemini-2.5-pro",
           "--max-iterations", "1",
+          "--tasks",
           "--no-commit",
           "--no-questions",
           "--no-stream",
@@ -295,8 +303,11 @@ echo '<promise>COMPLETE</promise>'
         "google/gemini-2.5-pro",
         "--approve",
       ]);
-      expect(piArgs.slice(5).join("\n")).toContain(
-        "Complete the task. Output <promise>COMPLETE</promise> when done.",
+      const piPrompt = piArgs.slice(5).join("\n");
+      expect(piPrompt).toContain("Complete the task. Output <promise>COMPLETE</promise> when done.");
+      expect(piPrompt).toContain("Verify Pi task mode");
+      expect(readFileSync(join(workdir, ".ralph", "ralph-tasks.md"), "utf-8")).toContain(
+        "- [x] Verify Pi task mode",
       );
     } finally {
       if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -242,6 +242,67 @@ describe("agent stream output extraction", () => {
   });
 });
 
+describe("Pi agent invocation", () => {
+  it("runs Pi in one-shot ephemeral mode", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-agent-test."));
+    const fakePi = join(workdir, "pi");
+    const capturedArgs = join(workdir, "pi-args.txt");
+    const rootDir = join(import.meta.dir, "..");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+printf '%s\\n' "$@" > "${capturedArgs}"
+echo '<promise>COMPLETE</promise>'
+`);
+      chmodSync(fakePi, 0o755);
+
+      const proc = Bun.spawn({
+        cmd: [
+          "bun",
+          join(rootDir, "ralph.ts"),
+          "Complete the task. Output <promise>COMPLETE</promise> when done.",
+          "--agent", "pi",
+          "--model", "google/gemini-2.5-pro",
+          "--max-iterations", "1",
+          "--no-commit",
+          "--no-questions",
+          "--no-stream",
+          "--no-allow-all",
+          "--",
+          "--approve",
+        ],
+        cwd: workdir,
+        env: { ...process.env, RALPH_PI_BINARY: fakePi },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("Iterative AI Development with Pi");
+      expect(stdout).toContain("Completion promise detected");
+      const piArgs = readFileSync(capturedArgs, "utf-8").split("\n");
+      expect(piArgs.slice(0, 5)).toEqual([
+        "-p",
+        "--no-session",
+        "--model",
+        "google/gemini-2.5-pro",
+        "--approve",
+      ]);
+      expect(piArgs.slice(5).join("\n")).toContain(
+        "Complete the task. Output <promise>COMPLETE</promise> when done.",
+      );
+    } finally {
+      if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("activity timeout retry", () => {
   it("kills an inactive agent and starts the next iteration", async () => {

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -404,23 +404,34 @@ describe("agent stream output extraction", () => {
 });
 
 describe("Pi agent invocation", () => {
-  it("runs Pi in one-shot ephemeral mode", async () => {
+  it("runs Pi in fresh RPC mode", async () => {
     const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-agent-test."));
     const fakePi = join(workdir, "pi");
     const capturedArgs = join(workdir, "pi-args.txt");
+    const capturedCommands = join(workdir, "pi-commands.jsonl");
     const rootDir = join(import.meta.dir, "..");
 
     try {
       writeFileSync(fakePi, `#!/usr/bin/env bash
 printf '%s\\n' "$@" > "${capturedArgs}"
-echo '{"type":"tool_execution_start","toolCallId":"call_1","toolName":"edit","args":{}}'
-cat > .ralph/ralph-tasks.md <<'TASKS'
+while IFS= read -r command; do
+  printf '%s\\n' "$command" >> "${capturedCommands}"
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo '{"type":"tool_execution_start","toolCallId":"call_1","toolName":"edit","args":{}}'
+    cat > .ralph/ralph-tasks.md <<'TASKS'
 # Ralph Tasks
 
 - [x] Verify Pi task mode
 TASKS
-echo '{"type":"tool_execution_end","toolCallId":"call_1","toolName":"edit","result":{},"isError":false}'
-echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    echo '{"type":"tool_execution_end","toolCallId":"call_1","toolName":"edit","result":{},"isError":false}'
+    echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    echo '{"type":"agent_end","messages":[],"willRetry":false}'
+    echo '{"type":"agent_settled"}'
+  fi
+done
 `);
       chmodSync(fakePi, 0o755);
       await Bun.$`mkdir -p ${join(workdir, ".ralph")}`;
@@ -458,19 +469,22 @@ echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"te
       expect(stdout).toContain("Iterative AI Development with Pi");
       expect(stdout).toContain("Completion promise detected");
       expect(stdout).toContain("Tools:     edit 1");
-      const piArgs = readFileSync(capturedArgs, "utf-8").split("\n");
-      expect(piArgs.slice(0, 7)).toEqual([
-        "-p",
-        "--no-session",
+      const piArgs = readFileSync(capturedArgs, "utf-8").trim().split("\n");
+      expect(piArgs).toEqual([
         "--mode",
-        "json",
+        "rpc",
+        "--no-session",
         "--model",
         "google/gemini-2.5-pro",
         "--approve",
       ]);
-      const piPrompt = piArgs.slice(7).join("\n");
-      expect(piPrompt).toContain("Complete the task. Output <promise>COMPLETE</promise> when done.");
-      expect(piPrompt).toContain("Verify Pi task mode");
+      const piCommands = readFileSync(capturedCommands, "utf-8")
+        .trim()
+        .split("\n")
+        .map(line => JSON.parse(line));
+      expect(piCommands.map(command => command.type)).toEqual(["prompt"]);
+      expect(piCommands[0].message).toContain("Complete the task. Output <promise>COMPLETE</promise> when done.");
+      expect(piCommands[0].message).toContain("Verify Pi task mode");
       expect(readFileSync(join(workdir, ".ralph", "ralph-tasks.md"), "utf-8")).toContain(
         "- [x] Verify Pi task mode",
       );
@@ -521,6 +535,57 @@ exit 1
       if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
     }
   });
+
+  it("ignores completion promises when Pi exits before agent_settled", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-unsettled-completion."));
+    const fakePi = join(workdir, "pi");
+    const rootDir = join(import.meta.dir, "..");
+
+    try {
+      writeFileSync(fakePi, `#!/usr/bin/env bash
+while IFS= read -r command; do
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    exit 0
+  fi
+done
+`);
+      chmodSync(fakePi, 0o755);
+
+      const proc = Bun.spawn({
+        cmd: [
+          "bun",
+          join(rootDir, "ralph.ts"),
+          "Do not finish without settlement.",
+          "--agent", "pi",
+          "--max-iterations", "1",
+          "--no-commit",
+          "--no-questions",
+          "--no-allow-all",
+        ],
+        cwd: workdir,
+        env: { ...process.env, RALPH_PI_BINARY: fakePi },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Completion promise: not detected");
+      expect(`${stdout}\n${stderr}`).toContain("exited before agent_settled");
+      expect(stdout).not.toContain("Task completed in");
+    } finally {
+      if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
+    }
+  });
 });
 
 it("ignores promise text from Pi user events until the assistant emits it", async () => {
@@ -531,16 +596,25 @@ it("ignores promise text from Pi user events until the assistant emits it", asyn
 
   try {
     writeFileSync(fakePi, `#!/usr/bin/env bash
-count=0
-if [ -f "${countFile}" ]; then count=$(cat "${countFile}"); fi
-count=$((count + 1))
-printf '%s' "$count" > "${countFile}"
-echo '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
-if [ "$count" -eq 1 ]; then
-  echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"One backlog item completed; continue."}]}}'
-else
-  echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
-fi
+while IFS= read -r command; do
+  if [[ "$command" == *'"type":"prompt"'* ]]; then
+    count=0
+    if [ -f "${countFile}" ]; then count=$(cat "${countFile}"); fi
+    count=$((count + 1))
+    printf '%s' "$count" > "${countFile}"
+    id=$(printf '%s' "$command" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
+    printf '{"type":"response","id":"%s","command":"prompt","success":true}\\n' "$id"
+    echo '{"type":"agent_start"}'
+    echo '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    if [ "$count" -eq 1 ]; then
+      echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"One backlog item completed; continue."}]}}'
+    else
+      echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+    fi
+    echo '{"type":"agent_end","messages":[],"willRetry":false}'
+    echo '{"type":"agent_settled"}'
+  fi
+done
 `);
     chmodSync(fakePi, 0o755);
 

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -8,6 +8,7 @@ import {
   extractAgentCompletionText,
   extractClaudeStreamDisplayLines,
   extractCursorAgentStreamDisplayLines,
+  extractPiStreamDisplayLines,
   getLastNonEmptyLine,
   tasksMarkdownAllComplete,
 } from "../completion";
@@ -205,6 +206,24 @@ describe("agent stream output extraction", () => {
     expect(extractCursorAgentStreamDisplayLines(line)).toEqual(["ready", "<promise>COMPLETE</promise>"]);
   });
 
+  it("extracts Pi assistant text and ignores lifecycle events", () => {
+    const output = [
+      JSON.stringify({ type: "session", version: 3 }),
+      JSON.stringify({ type: "tool_execution_start", toolName: "edit" }),
+      JSON.stringify({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "done\n<promise>COMPLETE</promise>" }],
+        },
+      }),
+    ].join("\n");
+
+    expect(extractPiStreamDisplayLines(output.split("\n")[0])).toEqual([]);
+    expect(extractPiStreamDisplayLines(output.split("\n")[1])).toEqual([]);
+    expect(checkTerminalPromise(extractAgentCompletionText(output, "pi"), "COMPLETE")).toBe(true);
+  });
+
   it("leaves non-streaming agents unchanged for completion detection", () => {
     const output = "Finished\n<promise>COMPLETE</promise>";
     expect(extractAgentCompletionText(output, "opencode")).toBe(output);
@@ -252,12 +271,14 @@ describe("Pi agent invocation", () => {
     try {
       writeFileSync(fakePi, `#!/usr/bin/env bash
 printf '%s\\n' "$@" > "${capturedArgs}"
+echo '{"type":"tool_execution_start","toolCallId":"call_1","toolName":"edit","args":{}}'
 cat > .ralph/ralph-tasks.md <<'TASKS'
 # Ralph Tasks
 
 - [x] Verify Pi task mode
 TASKS
-echo '<promise>COMPLETE</promise>'
+echo '{"type":"tool_execution_end","toolCallId":"call_1","toolName":"edit","result":{},"isError":false}'
+echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
 `);
       chmodSync(fakePi, 0o755);
       await Bun.$`mkdir -p ${join(workdir, ".ralph")}`;
@@ -274,7 +295,6 @@ echo '<promise>COMPLETE</promise>'
           "--tasks",
           "--no-commit",
           "--no-questions",
-          "--no-stream",
           "--no-allow-all",
           "--",
           "--approve",
@@ -295,15 +315,18 @@ echo '<promise>COMPLETE</promise>'
       expect(stderr).toBe("");
       expect(stdout).toContain("Iterative AI Development with Pi");
       expect(stdout).toContain("Completion promise detected");
+      expect(stdout).toContain("Tools:     edit 1");
       const piArgs = readFileSync(capturedArgs, "utf-8").split("\n");
-      expect(piArgs.slice(0, 5)).toEqual([
+      expect(piArgs.slice(0, 7)).toEqual([
         "-p",
         "--no-session",
+        "--mode",
+        "json",
         "--model",
         "google/gemini-2.5-pro",
         "--approve",
       ]);
-      const piPrompt = piArgs.slice(5).join("\n");
+      const piPrompt = piArgs.slice(7).join("\n");
       expect(piPrompt).toContain("Complete the task. Output <promise>COMPLETE</promise> when done.");
       expect(piPrompt).toContain("Verify Pi task mode");
       expect(readFileSync(join(workdir, ".ralph", "ralph-tasks.md"), "utf-8")).toContain(

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -338,6 +338,62 @@ echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"te
   });
 });
 
+it("ignores promise text from Pi user events until the assistant emits it", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "ralph-pi-completion-test."));
+  const fakePi = join(workdir, "pi");
+  const countFile = join(workdir, "pi-count.txt");
+  const rootDir = join(import.meta.dir, "..");
+
+  try {
+    writeFileSync(fakePi, `#!/usr/bin/env bash
+count=0
+if [ -f "${countFile}" ]; then count=$(cat "${countFile}"); fi
+count=$((count + 1))
+printf '%s' "$count" > "${countFile}"
+echo '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+if [ "$count" -eq 1 ]; then
+  echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"One backlog item completed; continue."}]}}'
+else
+  echo '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<promise>COMPLETE</promise>"}]}}'
+fi
+`);
+    chmodSync(fakePi, 0o755);
+
+    const proc = Bun.spawn({
+      cmd: [
+        "bun",
+        join(rootDir, "ralph.ts"),
+        "Process the backlog.",
+        "--agent", "pi",
+        "--max-iterations", "2",
+        "--no-commit",
+        "--no-questions",
+        "--no-allow-all",
+      ],
+      cwd: workdir,
+      env: { ...process.env, RALPH_PI_BINARY: fakePi },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(readFileSync(countFile, "utf-8")).toBe("2");
+    expect(stdout).toContain("One backlog item completed; continue.");
+    expect(stdout).toContain("Completion promise: not detected");
+    expect(stdout).toContain("Iteration 2 / 2");
+    expect(stdout).toContain("Completion promise detected");
+  } finally {
+    if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 describe("activity timeout retry", () => {
   it("kills an inactive agent and starts the next iteration", async () => {
     const workdir = mkdtempSync(join(tmpdir(), "ralph-activity-timeout-test."));

--- a/tests/sigint-cleanup.test.ts
+++ b/tests/sigint-cleanup.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, unlinkSync } from "fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 const stateDir = join(process.cwd(), ".ralph");
 const statePath = join(stateDir, "ralph-loop.state.json");
 const questionsPath = join(stateDir, "ralph-questions.json");
 const fakeOpencodePath = join(process.cwd(), "tests", "fixtures", "fake-opencode.ts");
+let controlDir = "";
 
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -47,6 +49,7 @@ function spawnRalph() {
       ...process.env,
       NODE_ENV: "test",
       RALPH_OPENCODE_BINARY: fakeOpencodePath,
+      RALPH_CONTROL_DIR: controlDir,
     },
   });
 
@@ -77,6 +80,7 @@ async function waitForRalphReady(run: ReturnType<typeof spawnRalph>) {
 
 describe("SIGINT cleanup", () => {
   beforeEach(() => {
+    controlDir = mkdtempSync(join(tmpdir(), "ralph-signal-control."));
     [statePath, questionsPath].forEach(path => {
       if (existsSync(path)) {
         try {
@@ -94,6 +98,7 @@ describe("SIGINT cleanup", () => {
         } catch {}
       }
     });
+    if (controlDir) rmSync(controlDir, { recursive: true, force: true });
   });
 
   it("stops heartbeat output after SIGINT", async () => {
@@ -129,6 +134,20 @@ describe("SIGINT cleanup", () => {
     await run.done();
 
     expect(existsSync(statePath)).toBe(false);
+    expect(readdirSync(controlDir)).toEqual([]);
+  });
+
+  it("cleans up loop control on SIGTERM", async () => {
+    const run = spawnRalph();
+
+    await waitForRalphReady(run);
+    run.proc.kill("SIGTERM");
+    const exitCode = await run.proc.exited;
+    await run.done();
+
+    expect(exitCode).toBe(143);
+    expect(existsSync(statePath)).toBe(false);
+    expect(readdirSync(controlDir)).toEqual([]);
   });
 
   it("handles double SIGINT", async () => {


### PR DESCRIPTION
## Summary

- add native `--agent pi` support while preserving all existing agent behavior
- run every Pi iteration as a fresh `pi --mode rpc --no-session` process
- add `ralph --steer "TEXT"` to steer the currently active Pi iteration
- wait until Pi consumes steering at a safe turn boundary before reporting success
- fail explicitly for non-Pi agents, iteration gaps, ended iterations, and ambiguous concurrent loops
- keep `--add-context` as a separate next-iteration mechanism; there is no implicit fallback and no `--abort-current`

## Design

`AgentIteration` is the execution seam. Its ordinary-process adapter retains the existing one-shot spawn, output, timeout, telemetry, and cleanup behavior. Its Pi adapter owns RPC stdin/stdout framing, response correlation, bounded reduction, extension UI cancellation, safe-boundary steering delivery, `agent_settled`, heartbeat, timeout, and child cleanup.

`LoopControl` is the local-control seam. It owns workspace discovery, private runtime descriptors, authentication tokens, generation leases, Unix sockets / Windows named pipes, request limits, conservative stale cleanup, and signal cleanup. Runtime artifacts live outside the target repository and are not included by Ralph's `git add -A` flow.

Pi prompts and steering text are sent through child stdin, not child argv. Ralph does not write steering text to loop state, history, context, or logs. Pi remains sessionless and a new process is started for every iteration.

## Usage

Start a Pi loop:

```bash
ralph "Implement the task" --agent pi
```

From another terminal in the same workspace:

```bash
ralph --steer "Focus on the failing integration test"
```

The steering command may wait while Pi is inside a long tool call. Exit code 0 means the queued instruction crossed Pi's safe turn boundary, not merely that the RPC command was accepted.

## Verification

- `bun run test`: 65 passed, 0 failed
- focused source typecheck for the extracted modules
- `bun build ralph.ts --target=bun`
- `npm pack --dry-run`: `agent-iteration.ts` and `loop-control.ts` included
- `git diff --check`
- Standards and Spec review with blocking findings closed

Live smoke used installed Pi `0.83.0` with `sub2api/gpt-5.6-sol` and extension discovery disabled. A real Pi iteration started an eight-second bash tool call; `ralph --steer` was issued during that call and returned after 8.011 seconds, Pi then wrote the exact steered result, Ralph detected the completion promise, both processes exited 0, and control/state cleanup completed with no residual process or runtime artifact.

Official Pi usage reference: https://pi.dev
